### PR TITLE
v0.1.1: Integer variables, addition operator, and printf display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ coverage:
 	mkdir build
 	cd build && cmake -DOUTPUT_COVERAGE=ON ..
 	cmake --build build
+	cd build && bin/c2ast-tester
 	cd build && bin/gen-ast-tester
+	cd build && bin/sa-tester
+	cd build && bin/codegen-tester
 	cd build && bin/build-mgr-tester
 	cd build && lcov -c -d . -b src -o all.info --rc branch_coverage=1 --ignore-errors mismatch
 	cd build && lcov -e all.info '*/palanx/src/*' -o lcov.info --rc branch_coverage=1

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 all: build/CMakeCache.txt
 	cmake --build build
+	find build -name "*.gcda" -delete 2>/dev/null; true
 	@cd build && rm -f bin/core && bin/c2ast-tester
 	@cd build && rm -f bin/core && bin/gen-ast-tester
 	@cd build && rm -f bin/core && bin/sa-tester

--- a/doc/ASTSpec.md
+++ b/doc/ASTSpec.md
@@ -85,7 +85,7 @@ Note: C `restrict` qualifier is not represented in the AST (optimization hint on
 
 Statement model
 ---------------
-- stmt-type - Statement type: "import" "cinclude" "expr"
+- stmt-type - Statement type: "import" "cinclude" "expr" "var-decl"
   1. import - import module statement
     - path-type\* - Path type string: "src" "inc"
     - path\* - Path string
@@ -97,10 +97,15 @@ Statement model
     - functions - Function definition model list (C prototypes from the header)
   3. expr - expression statement
     - body\* - Expression model
+  4. var-decl - variable declaration statement
+    - vars\* - Variable declaration list
+      - var-name\* - Variable name string
+      - var-type\* - Variable type
+      - init - Initializer expression model (omitted if no initializer)
 
 Expression model
 ----------------
-- expr-type\* - Expression type string: "lit-str" "lit-int" "lit-uint" "id" "call"
+- expr-type\* - Expression type string: "lit-str" "lit-int" "lit-uint" "id" "add" "call"
   1. lit-str - String literal
     - value\* - String value
   2. lit-int - Signed integer literal (corresponds to INT token)
@@ -109,7 +114,10 @@ Expression model
     - value\* - Decimal string (e.g. "10")
   4. id - Identifier (variable reference)
     - name\* - Identifier name string
-  5. call - Function call expression
+  5. add - Binary addition
+    - left\*  - Left operand expression model
+    - right\* - Right operand expression model
+  6. call - Function call expression
     - name\* - Function name string
     - args - Argument expression list
 

--- a/doc/SpecAndDesign.md
+++ b/doc/SpecAndDesign.md
@@ -178,6 +178,28 @@ manages these flags automatically.
 For testing with stub headers instead of real system headers, place stub `.h` files
 in a directory and pass it as a search path via the `-p` option to `palan-c2ast`.
 
+### 4.4 Integer Variables and Arithmetic (v0.1.1)
+
+Palan supports 64-bit integer variable declaration with initialization and addition expressions.
+
+```
+cinclude <stdio.h>;
+
+int64 x = 10;
+int64 y = 20;
+printf("%lld\n", x);        // display a variable: 10
+printf("%lld\n", x + y);    // display an expression: 30
+```
+
+Build and run:
+
+```bash
+bin/palan add.pa
+./a.out
+# 10
+# 30
+```
+
 ## 5. Working Directory and Output Files
 ### 5.1 Working Directory
 The working directory for all command-line tools is `~/.palan/work/` by default.

--- a/doc/SpecAndDesign.md
+++ b/doc/SpecAndDesign.md
@@ -144,41 +144,12 @@ cinclude <stdio.h>;
 printf("Hello World!\n");
 ```
 
-Build and run:
-
 ```bash
-bin/palan hello.pa
-./a.out
+bin/palan hello.pa && ./a.out
 # Hello World!
 ```
 
-### 4.2 Calling C Standard Library Functions
-
-Palan imports C function declarations using `cinclude`. The `cinclude` statement causes
-`palan-gen-ast` to invoke `palan-c2ast` internally to translate the C header into AST nodes.
-Imported functions are resolved to their C ABI counterparts during semantic analysis.
-
-```
-cinclude <stdio.h>;
-cinclude <stdlib.h>;
-
-printf("value: %d\n");
-```
-
-### 4.3 System Include Path Configuration
-
-`palan-c2ast` reads predefined macros from `./c2ast/predefined.h` relative to the
-executable's location. This file is automatically copied to the build output directory
-by CMake.
-
-System headers are resolved by passing `-p <path>` flags (for additional search paths)
-and `-s` (to mark the input as a system header). In the normal pipeline, `palan-gen-ast`
-manages these flags automatically.
-
-For testing with stub headers instead of real system headers, place stub `.h` files
-in a directory and pass it as a search path via the `-p` option to `palan-c2ast`.
-
-### 4.4 Integer Variables and Arithmetic
+### 4.2 Integer Variables and Arithmetic
 
 ```
 cinclude <stdio.h>;

--- a/doc/SpecAndDesign.md
+++ b/doc/SpecAndDesign.md
@@ -29,7 +29,8 @@ Responsibility:
 
 Usage: palan [options] <source files>
  options:
-   -o, --output <file path> Specify output file path. If not specified, defaults to 'a.out'
+   -o, --output <file path> Specify output file path. If not specified, the binary is
+                            executed immediately after linking and then removed.
    -c, --clean              Clean build artifacts
    -h, --help               Display help information
    -v, --version            Display version information
@@ -39,7 +40,9 @@ Design:
  After generating ASTs of the source files by invoking palan-gen-ast, it checks for dependencies on other Palan source files and invokes palan-gen-ast for those dependent files if needed.
  After generating ASTs for all source files, it invokes palan-sa to perform semantic analysis on the generated ASTs.
  It then invokes palan-codegen to generate x86-64 assembly files from the analyzed ASTs,
- assembles them with `as`, and links the resulting object files with `ld` to create the final executable.
+ assembles them with `as`, and links the resulting object files with `ld` to create the final executable (default: `a.out`).
+ If `-o` is not specified, the resulting `a.out` is executed immediately after linking and then removed.
+ This allows palan to be used as a script runner without leaving build artifacts.
  Before linking, the build manager reads ast.json for each source file and collects `link` declarations
  from `cinclude` statements (e.g. `cinclude <stdio.h> link "c";`), passing the corresponding `-l` flags to `ld`.
  This link declaration feature is designed but not yet implemented; linking flags are handled manually in the interim.

--- a/doc/SpecAndDesign.md
+++ b/doc/SpecAndDesign.md
@@ -178,25 +178,17 @@ manages these flags automatically.
 For testing with stub headers instead of real system headers, place stub `.h` files
 in a directory and pass it as a search path via the `-p` option to `palan-c2ast`.
 
-### 4.4 Integer Variables and Arithmetic (v0.1.1)
-
-Palan supports 64-bit integer variable declaration with initialization and addition expressions.
+### 4.4 Integer Variables and Arithmetic
 
 ```
 cinclude <stdio.h>;
-
 int64 x = 10;
 int64 y = 20;
-printf("%lld\n", x);        // display a variable: 10
-printf("%lld\n", x + y);    // display an expression: 30
+printf("%lld\n", x + y);
 ```
 
-Build and run:
-
 ```bash
-bin/palan add.pa
-./a.out
-# 10
+bin/palan add.pa && ./a.out
 # 30
 ```
 

--- a/src/build-mgr/main.cpp
+++ b/src/build-mgr/main.cpp
@@ -22,15 +22,18 @@ static string getPalanDirPath();
 int main(int argc, char* argv[])
 {
 	struct option long_options[] = {
-		{ "help", no_argument, NULL, 'h' },
-		{ "clean", no_argument, NULL, 'c' },
+		{ "help",   no_argument,       NULL, 'h' },
+		{ "clean",  no_argument,       NULL, 'c' },
+		{ "output", required_argument, NULL, 'o' },
 		{ 0 }
 	};
 
 	int opt, option_index = 0;
 	bool do_clean = false;
+	string binary_name = "a.out";
+	bool output_specified = false;
 
-	while (0 < (opt = getopt_long(argc, argv, "h:", long_options, NULL))) {
+	while (0 < (opt = getopt_long(argc, argv, "hco:", long_options, NULL))) {
 		switch (opt) {
 			case 'h':
 				cout << "help" << endl;
@@ -38,10 +41,14 @@ int main(int argc, char* argv[])
 			case 'c':
 				do_clean = true;
 				break;
+			case 'o':
+				binary_name = optarg;
+				output_specified = true;
+				break;
 			default:
 				break;
 		}
-	} 
+	}
 
 	string palan_dir_path = getPalanDirPath();
 	string palan_work_path = palan_dir_path + "/work";
@@ -158,7 +165,6 @@ int main(int argc, char* argv[])
 
 	// ld — link all object files into the final binary
 	// TODO: extract required libraries from AST cinclude link clauses
-	string binary_name = "a.out";
 	string ldcmd = "ld";
 	for (auto& obj : obj_files) ldcmd += " " + obj;
 	ldcmd += " -lc -dynamic-linker /lib64/ld-linux-x86-64.so.2 -o " + binary_name;
@@ -167,6 +173,15 @@ int main(int argc, char* argv[])
 		ret = WEXITSTATUS(ret);
 		if (ret) return ret;
 	} else {
+		return -1;
+	}
+
+	// When no explicit output is specified, run the binary and remove it.
+	// This enables script-style usage: palan script.pa
+	if (!output_specified) {
+		int run_ret = system(("./" + binary_name).c_str());
+		fs::remove(binary_name);
+		if (WIFEXITED(run_ret)) return WEXITSTATUS(run_ret);
 		return -1;
 	}
 

--- a/src/codegen/PlnDeserialize.cpp
+++ b/src/codegen/PlnDeserialize.cpp
@@ -27,6 +27,12 @@ static unique_ptr<Expr> deserializeExpr(const json& j)
         e->name = j["name"];
         return e;
     }
+    if (expr_type == "add") {
+        auto e = make_unique<AddExpr>();
+        e->left  = deserializeExpr(j["left"]);
+        e->right = deserializeExpr(j["right"]);
+        return e;
+    }
     if (expr_type == "call") {
         string func_type = j.value("func-type", "");
         if (func_type == "c") {

--- a/src/codegen/PlnDeserialize.cpp
+++ b/src/codegen/PlnDeserialize.cpp
@@ -63,6 +63,19 @@ static unique_ptr<Stmt> deserializeStmt(const json& j)
         s->body = deserializeExpr(j["body"]);
         return s;
     }
+    if (stmt_type == "var-decl") {
+        auto s = make_unique<VarDeclStmt>();
+        for (auto& jv : j["vars"]) {
+            VarEntry ve;
+            ve.varName  = jv["var-name"];
+            ve.typeName = jv["var-type"]["type-name"];
+            if (jv.contains("init")) {
+                ve.init = deserializeExpr(jv["init"]);
+            }
+            s->vars.push_back(move(ve));
+        }
+        return s;
+    }
     if (stmt_type == "not-impl") {
         return nullptr;
     }

--- a/src/codegen/PlnNode.h
+++ b/src/codegen/PlnNode.h
@@ -54,6 +54,16 @@ struct ExprStmt : Stmt {
     unique_ptr<Expr> body;
 };
 
+struct VarEntry {
+    string           varName;
+    string           typeName;   // "int64" etc.
+    unique_ptr<Expr> init;       // nullable
+};
+
+struct VarDeclStmt : Stmt {
+    vector<VarEntry> vars;
+};
+
 // -------- Module --------
 
 struct StrLiteralDef {

--- a/src/codegen/PlnNode.h
+++ b/src/codegen/PlnNode.h
@@ -14,43 +14,77 @@ using std::unique_ptr;
 
 // -------- Expressions --------
 
+enum class ExprKind {
+    StrLit,
+    IntLit,
+    UintLit,
+    Id,
+    Add,
+    CCCall,
+    PlnCall,
+};
+
 struct Expr {
+    const ExprKind kind;
     virtual ~Expr() = default;
+protected:
+    explicit Expr(ExprKind k) : kind(k) {}
 };
 
 struct StrLitExpr : Expr {
+    StrLitExpr() : Expr(ExprKind::StrLit) {}
     string value;
 };
 
 struct IntLitExpr : Expr {
+    IntLitExpr() : Expr(ExprKind::IntLit) {}
     string value;  // decimal string
 };
 
 struct UintLitExpr : Expr {
+    UintLitExpr() : Expr(ExprKind::UintLit) {}
     string value;  // decimal string
 };
 
 struct IdExpr : Expr {
+    IdExpr() : Expr(ExprKind::Id) {}
     string name;
 };
 
+struct AddExpr : Expr {
+    AddExpr() : Expr(ExprKind::Add) {}
+    unique_ptr<Expr> left;
+    unique_ptr<Expr> right;
+};
+
 struct CCCallExpr : Expr {
+    CCCallExpr() : Expr(ExprKind::CCCall) {}
     string name;
     vector<unique_ptr<Expr>> args;
 };
 
 struct PlnCallExpr : Expr {
+    PlnCallExpr() : Expr(ExprKind::PlnCall) {}
     string name;
     vector<unique_ptr<Expr>> args;
 };
 
 // -------- Statements --------
 
+enum class StmtKind {
+    Expr,
+    VarDecl,
+};
+
 struct Stmt {
+    const StmtKind kind;
     virtual ~Stmt() = default;
+protected:
+    explicit Stmt(StmtKind k) : kind(k) {}
 };
 
 struct ExprStmt : Stmt {
+    ExprStmt() : Stmt(StmtKind::Expr) {}
     unique_ptr<Expr> body;
 };
 
@@ -61,6 +95,7 @@ struct VarEntry {
 };
 
 struct VarDeclStmt : Stmt {
+    VarDeclStmt() : Stmt(StmtKind::VarDecl) {}
     vector<VarEntry> vars;
 };
 

--- a/src/codegen/PlnRegAlloc.cpp
+++ b/src/codegen/PlnRegAlloc.cpp
@@ -8,11 +8,11 @@ RegAllocResult allocateRegisters(const VFunc& func, const PhysRegs& phys)
 {
     // Step 1: Collect VReg metadata.
     struct VRegMeta {
-        VRegType type    = VRegType::Int64;
-        int      def_idx = -1;
-        bool     isVar   = false;  // true if defined by InitVar (variable)
-        // (call_instr_idx, arg_position) for each use as a call argument
-        vector<pair<int,int>> uses;
+        VRegType type         = VRegType::Int64;
+        int      def_idx      = -1;
+        bool     isVar        = false;   // true if defined by InitVar (variable)
+        int      last_any_use = -1;      // last use by Add (non-call) instructions
+        vector<pair<int,int>> call_uses; // (call_instr_idx, arg_position)
     };
     map<VReg, VRegMeta> meta;
 
@@ -30,10 +30,15 @@ RegAllocResult allocateRegisters(const VFunc& func, const PhysRegs& phys)
             meta[v->dst].def_idx = i;
             meta[v->dst].type    = v->type;
             meta[v->dst].isVar   = true;
+        } else if (auto* a = get_if<Add>(&instr)) {
+            meta[a->dst].def_idx = i;
+            meta[a->dst].type    = a->type;
+            meta[a->lhs].last_any_use = max(meta[a->lhs].last_any_use, i);
+            meta[a->rhs].last_any_use = max(meta[a->rhs].last_any_use, i);
         } else if (auto* c = get_if<CallC>(&instr)) {
             call_indices.push_back(i);
             for (int j = 0; j < (int)c->args.size(); j++) {
-                meta[c->args[j]].uses.push_back({i, j});
+                meta[c->args[j]].call_uses.push_back({i, j});
             }
         }
     }
@@ -48,20 +53,32 @@ RegAllocResult allocateRegisters(const VFunc& func, const PhysRegs& phys)
         result[vreg] = PhysLoc{"", type, -8 * stack_slots};
     };
 
+    auto allocCalleeSavedOrStack = [&](VReg vreg, VRegType type) {
+        if (callee_idx < (int)phys.calleeSaved.size()) {
+            result[vreg] = PhysLoc{phys.calleeSaved[callee_idx++], type};
+        } else {
+            allocStackSlot(vreg, type);
+        }
+    };
+
     for (auto& [vreg, m] : meta) {
-        // InitVar VReg with no uses: store side-effect must be preserved.
-        // Assign a stack slot so the emitter can still store the value.
-        if (m.uses.empty()) {
-            if (m.isVar) allocStackSlot(vreg, m.type);
+        if (m.call_uses.empty()) {
+            if (m.isVar) {
+                allocStackSlot(vreg, m.type);
+            } else if (m.last_any_use >= 0) {
+                // Used only as Add operand (not directly by any call)
+                allocCalleeSavedOrStack(vreg, m.type);
+            }
+            // else: dead — no allocation needed
             continue;
         }
 
-        // Determine whether this VReg must survive across a call.
+        // Has call uses — determine whether callee-saved is needed.
         bool needs_callee_saved = false;
-        if (m.uses.size() > 1) {
+        if (m.call_uses.size() > 1) {
             needs_callee_saved = true;
         } else {
-            int use_idx = m.uses.front().first;
+            int use_idx = m.call_uses.front().first;
             for (int c_idx : call_indices) {
                 if (m.def_idx < c_idx && c_idx < use_idx) {
                     needs_callee_saved = true;
@@ -71,15 +88,9 @@ RegAllocResult allocateRegisters(const VFunc& func, const PhysRegs& phys)
         }
 
         if (needs_callee_saved) {
-            if (callee_idx < (int)phys.calleeSaved.size()) {
-                result[vreg] = PhysLoc{phys.calleeSaved[callee_idx++], m.type};
-            } else {
-                // Callee-saved registers exhausted: spill to stack.
-                allocStackSlot(vreg, m.type);
-            }
+            allocCalleeSavedOrStack(vreg, m.type);
         } else {
-            // Assign directly to the required argument register.
-            int arg_pos = m.uses.front().second;
+            int arg_pos = m.call_uses.front().second;
             BOOST_ASSERT(arg_pos < (int)phys.intArgs.size());
             result[vreg] = PhysLoc{phys.intArgs[arg_pos], m.type};
         }

--- a/src/codegen/PlnRegAlloc.cpp
+++ b/src/codegen/PlnRegAlloc.cpp
@@ -1,27 +1,73 @@
 #include "PlnRegAlloc.h"
 #include <boost/assert.hpp>
+#include <algorithm>
+
+using namespace std;
 
 RegMap allocateRegisters(const VFunc& func, const PhysRegs& phys)
 {
-    RegMap result;
-    int intArgIdx   = 0;
-    int floatArgIdx = 0;
+    // Step 1: Collect VReg metadata.
+    struct VRegMeta {
+        VRegType type   = VRegType::Int64;
+        int      def_idx = -1;
+        // (call_instr_idx, arg_position) for each use as a call argument
+        vector<pair<int,int>> uses;
+    };
+    map<VReg, VRegMeta> meta;
 
-    for (auto& instr : func.instrs) {
-        if (auto* i = std::get_if<LeaLabel>(&instr)) {
-            // Ptr64 -> integer argument register
-            BOOST_ASSERT(intArgIdx < (int)phys.intArgs.size());
-            result[i->dst] = PhysLoc{phys.intArgs[intArgIdx++], i->type};
-        } else if (auto* i = std::get_if<MovImm>(&instr)) {
-            // integer immediate -> integer argument register
-            BOOST_ASSERT(intArgIdx < (int)phys.intArgs.size());
-            result[i->dst] = PhysLoc{phys.intArgs[intArgIdx++], i->type};
-        } else if (std::get_if<CallC>(&instr)) {
-            // Reset both counters for the next call's arguments
-            intArgIdx   = 0;
-            floatArgIdx = 0;
+    vector<int> call_indices;  // instruction indices of all CallC
+
+    for (int i = 0; i < (int)func.instrs.size(); i++) {
+        auto& instr = func.instrs[i];
+        if (auto* l = get_if<LeaLabel>(&instr)) {
+            meta[l->dst].def_idx = i;
+            meta[l->dst].type    = l->type;
+        } else if (auto* m = get_if<MovImm>(&instr)) {
+            meta[m->dst].def_idx = i;
+            meta[m->dst].type    = m->type;
+        } else if (auto* c = get_if<CallC>(&instr)) {
+            call_indices.push_back(i);
+            for (int j = 0; j < (int)c->args.size(); j++) {
+                meta[c->args[j]].uses.push_back({i, j});
+            }
         }
-        // ExitCode: no registers involved
+    }
+
+    // Step 2: Assign physical registers.
+    RegMap result;
+    int callee_idx = 0;
+
+    for (auto& [vreg, m] : meta) {
+        if (m.uses.empty()) continue;  // defined but never used as call arg
+
+        int last_use_idx = max_element(m.uses.begin(), m.uses.end())->first;
+
+        // A VReg needs a callee-saved register if:
+        //   (a) it is used as an argument in more than one call (must survive across calls), or
+        //   (b) there is a call between its definition and its (single) use that would
+        //       clobber a caller-saved register.
+        bool needs_callee_saved = false;
+        if (m.uses.size() > 1) {
+            needs_callee_saved = true;
+        } else {
+            int use_idx = m.uses.front().first;
+            for (int c_idx : call_indices) {
+                if (m.def_idx < c_idx && c_idx < use_idx) {
+                    needs_callee_saved = true;
+                    break;
+                }
+            }
+        }
+
+        if (needs_callee_saved) {
+            BOOST_ASSERT(callee_idx < (int)phys.calleeSaved.size());
+            result[vreg] = PhysLoc{phys.calleeSaved[callee_idx++], m.type};
+        } else {
+            // Assign directly to the required argument register.
+            int arg_pos = m.uses.front().second;
+            BOOST_ASSERT(arg_pos < (int)phys.intArgs.size());
+            result[vreg] = PhysLoc{phys.intArgs[arg_pos], m.type};
+        }
     }
 
     return result;

--- a/src/codegen/PlnRegAlloc.cpp
+++ b/src/codegen/PlnRegAlloc.cpp
@@ -4,12 +4,13 @@
 
 using namespace std;
 
-RegMap allocateRegisters(const VFunc& func, const PhysRegs& phys)
+RegAllocResult allocateRegisters(const VFunc& func, const PhysRegs& phys)
 {
     // Step 1: Collect VReg metadata.
     struct VRegMeta {
-        VRegType type   = VRegType::Int64;
+        VRegType type    = VRegType::Int64;
         int      def_idx = -1;
+        bool     isVar   = false;  // true if defined by InitVar (variable)
         // (call_instr_idx, arg_position) for each use as a call argument
         vector<pair<int,int>> uses;
     };
@@ -25,30 +26,37 @@ RegMap allocateRegisters(const VFunc& func, const PhysRegs& phys)
         } else if (auto* m = get_if<MovImm>(&instr)) {
             meta[m->dst].def_idx = i;
             meta[m->dst].type    = m->type;
+        } else if (auto* v = get_if<InitVar>(&instr)) {
+            meta[v->dst].def_idx = i;
+            meta[v->dst].type    = v->type;
+            meta[v->dst].isVar   = true;
         } else if (auto* c = get_if<CallC>(&instr)) {
             call_indices.push_back(i);
             for (int j = 0; j < (int)c->args.size(); j++) {
                 meta[c->args[j]].uses.push_back({i, j});
             }
-        } else if (auto* l = get_if<LoadFromStack>(&instr)) {
-            meta[l->dst].def_idx = i;
-            meta[l->dst].type    = l->type;
         }
     }
 
-    // Step 2: Assign physical registers.
+    // Step 2: Assign physical registers or stack slots.
     RegMap result;
-    int callee_idx = 0;
+    int callee_idx  = 0;
+    int stack_slots = 0;  // number of 8-byte stack slots used
+
+    auto allocStackSlot = [&](VReg vreg, VRegType type) {
+        stack_slots++;
+        result[vreg] = PhysLoc{"", type, -8 * stack_slots};
+    };
 
     for (auto& [vreg, m] : meta) {
-        if (m.uses.empty()) continue;  // defined but never used as call arg
+        // InitVar VReg with no uses: store side-effect must be preserved.
+        // Assign a stack slot so the emitter can still store the value.
+        if (m.uses.empty()) {
+            if (m.isVar) allocStackSlot(vreg, m.type);
+            continue;
+        }
 
-        int last_use_idx = max_element(m.uses.begin(), m.uses.end())->first;
-
-        // A VReg needs a callee-saved register if:
-        //   (a) it is used as an argument in more than one call (must survive across calls), or
-        //   (b) there is a call between its definition and its (single) use that would
-        //       clobber a caller-saved register.
+        // Determine whether this VReg must survive across a call.
         bool needs_callee_saved = false;
         if (m.uses.size() > 1) {
             needs_callee_saved = true;
@@ -63,8 +71,12 @@ RegMap allocateRegisters(const VFunc& func, const PhysRegs& phys)
         }
 
         if (needs_callee_saved) {
-            BOOST_ASSERT(callee_idx < (int)phys.calleeSaved.size());
-            result[vreg] = PhysLoc{phys.calleeSaved[callee_idx++], m.type};
+            if (callee_idx < (int)phys.calleeSaved.size()) {
+                result[vreg] = PhysLoc{phys.calleeSaved[callee_idx++], m.type};
+            } else {
+                // Callee-saved registers exhausted: spill to stack.
+                allocStackSlot(vreg, m.type);
+            }
         } else {
             // Assign directly to the required argument register.
             int arg_pos = m.uses.front().second;
@@ -73,5 +85,11 @@ RegMap allocateRegisters(const VFunc& func, const PhysRegs& phys)
         }
     }
 
-    return result;
+    // Align frame size to 16 bytes.
+    // After pushq %rbp the stack is offset by 8, so we need frameSize ≡ 8 (mod 16)
+    // to keep rsp 16-byte aligned before each call.
+    int frameSize = stack_slots * 8;
+    if (frameSize > 0 && frameSize % 16 == 0) frameSize += 8;
+
+    return {result, frameSize};
 }

--- a/src/codegen/PlnRegAlloc.cpp
+++ b/src/codegen/PlnRegAlloc.cpp
@@ -30,6 +30,9 @@ RegMap allocateRegisters(const VFunc& func, const PhysRegs& phys)
             for (int j = 0; j < (int)c->args.size(); j++) {
                 meta[c->args[j]].uses.push_back({i, j});
             }
+        } else if (auto* l = get_if<LoadFromStack>(&instr)) {
+            meta[l->dst].def_idx = i;
+            meta[l->dst].type    = l->type;
         }
     }
 

--- a/src/codegen/PlnRegAlloc.cpp
+++ b/src/codegen/PlnRegAlloc.cpp
@@ -12,6 +12,10 @@ RegMap allocateRegisters(const VFunc& func, const PhysRegs& phys)
             // Ptr64 -> integer argument register
             BOOST_ASSERT(intArgIdx < (int)phys.intArgs.size());
             result[i->dst] = PhysLoc{phys.intArgs[intArgIdx++], i->type};
+        } else if (auto* i = std::get_if<MovImm>(&instr)) {
+            // integer immediate -> integer argument register
+            BOOST_ASSERT(intArgIdx < (int)phys.intArgs.size());
+            result[i->dst] = PhysLoc{phys.intArgs[intArgIdx++], i->type};
         } else if (std::get_if<CallC>(&instr)) {
             // Reset both counters for the next call's arguments
             intArgIdx   = 0;

--- a/src/codegen/PlnRegAlloc.h
+++ b/src/codegen/PlnRegAlloc.h
@@ -13,15 +13,22 @@ using std::map;
 using std::string;
 using std::vector;
 
-// Physical register location: base name (64-bit form) + data type.
-// The emitter derives the sized register name from (base, type):
-//   e.g. base="%rdi", type=Int32 -> "%edi"
+// Physical register location: either a physical register or a stack slot.
+//   base non-empty → register (64-bit name, e.g. "%rdi")
+//   base empty     → stack slot; stackOffset is the %rbp-relative offset (e.g. -8)
 struct PhysLoc {
-    string   base;  // 64-bit base name: "%rdi", "%xmm0", etc.
+    string   base;           // 64-bit base name; empty if stack slot
     VRegType type;
+    int      stackOffset = 0;  // valid when base is empty
+    bool isStack() const { return base.empty(); }
 };
 
 using RegMap = map<VReg, PhysLoc>;
+
+struct RegAllocResult {
+    RegMap regMap;
+    int    frameSize;  // bytes to reserve on stack (0 if no spills/callee-saves needed)
+};
 
 // Physical register lists (architecture-specific, passed in by caller)
 struct PhysRegs {
@@ -31,10 +38,12 @@ struct PhysRegs {
 };
 
 // Live-range-based register allocator.
-// Assigns each VReg to a physical register:
-//   - VRegs used only within one call segment (def to use, no intervening call)
-//     are assigned directly to the required argument register.
-//   - VRegs live across a call are assigned to a callee-saved register;
-//     the x86 emitter inserts moves to argument registers at each call site.
-//   - Spill to stack only when physical registers are exhausted (not-impl yet).
-RegMap allocateRegisters(const VFunc& func, const PhysRegs& phys);
+// Assigns each VReg to a physical register or stack slot:
+//   - VRegs used only within one call segment (no intervening call) →
+//     assigned directly to the required argument register.
+//   - VRegs live across a call → callee-saved register.
+//   - When callee-saved registers are exhausted → spill to stack slot.
+//   - InitVar VRegs with no uses → stack slot (preserves the store side-effect).
+//
+// Returns RegAllocResult containing the RegMap and the required frame size.
+RegAllocResult allocateRegisters(const VFunc& func, const PhysRegs& phys);

--- a/src/codegen/PlnRegAlloc.h
+++ b/src/codegen/PlnRegAlloc.h
@@ -25,15 +25,16 @@ using RegMap = map<VReg, PhysLoc>;
 
 // Physical register lists (architecture-specific, passed in by caller)
 struct PhysRegs {
-    vector<string> intArgs;    // integer/pointer arg regs: "%rdi", "%rsi", ...
-    vector<string> floatArgs;  // floating-point arg regs: "%xmm0", "%xmm1", ...
+    vector<string> intArgs;     // integer/pointer arg regs: "%rdi", "%rsi", ...
+    vector<string> floatArgs;   // floating-point arg regs: "%xmm0", "%xmm1", ...
+    vector<string> calleeSaved; // callee-saved regs: "%rbx", "%r12", ...
 };
 
-// Trivial allocator: assigns VRegs to physical registers based on instruction kind.
-// Register kind is inferred from the defining instruction:
-//   LeaLabel -> pointer -> intArgs[intArgIdx++]
-//   (future) LoadDbl -> float -> floatArgs[floatArgIdx++]
-// Both counters reset after each CallC.
-//
-// Future: replace this function with a proper live-range-based allocator.
+// Live-range-based register allocator.
+// Assigns each VReg to a physical register:
+//   - VRegs used only within one call segment (def to use, no intervening call)
+//     are assigned directly to the required argument register.
+//   - VRegs live across a call are assigned to a callee-saved register;
+//     the x86 emitter inserts moves to argument registers at each call site.
+//   - Spill to stack only when physical registers are exhausted (not-impl yet).
 RegMap allocateRegisters(const VFunc& func, const PhysRegs& phys);

--- a/src/codegen/PlnVCodeGen.cpp
+++ b/src/codegen/PlnVCodeGen.cpp
@@ -72,15 +72,11 @@ VReg PlnVCodeGen::lowerExpr(const Expr& expr, VFunc& func)
             func.instrs.push_back(Add{dst, l, r, VRegType::Int64});
             return dst;
         }
-        case ExprKind::CCCall:
-            lowerCCCallExpr(static_cast<const CCCallExpr&>(expr), func);
-            return -1;  // call expr: no result VReg
-        case ExprKind::PlnCall:
-            lowerPlnCallExpr(static_cast<const PlnCallExpr&>(expr), func);
+        default:
+            // CCCall/PlnCall do not produce a value; use lowerExprStmt instead.
+            BOOST_ASSERT(false);
             return -1;
     }
-    BOOST_ASSERT(false);  // unreachable
-    return -1;
 }
 
 void PlnVCodeGen::lowerCCCallExpr(const CCCallExpr& expr, VFunc& func)
@@ -99,7 +95,16 @@ void PlnVCodeGen::lowerPlnCallExpr(const PlnCallExpr& expr, VFunc& func)
 
 void PlnVCodeGen::lowerExprStmt(const ExprStmt& stmt, VFunc& func)
 {
-    lowerExpr(*stmt.body, func);
+    switch (stmt.body->kind) {
+        case ExprKind::CCCall:
+            lowerCCCallExpr(static_cast<const CCCallExpr&>(*stmt.body), func);
+            return;
+        case ExprKind::PlnCall:
+            lowerPlnCallExpr(static_cast<const PlnCallExpr&>(*stmt.body), func);
+            return;
+        default:
+            BOOST_ASSERT(false);  // only call expressions are valid as statements
+    }
 }
 
 void PlnVCodeGen::lowerVarDeclStmt(const VarDeclStmt& stmt, VFunc& func)

--- a/src/codegen/PlnVCodeGen.cpp
+++ b/src/codegen/PlnVCodeGen.cpp
@@ -3,6 +3,35 @@
 
 using namespace std;
 
+// -------- Variable scope management --------
+
+void PlnVCodeGen::enterVarScope()
+{
+    varScopes.push_back({});
+}
+
+void PlnVCodeGen::leaveVarScope()
+{
+    varScopes.pop_back();
+}
+
+VReg PlnVCodeGen::findVar(const string& name) const
+{
+    for (auto it = varScopes.rbegin(); it != varScopes.rend(); ++it) {
+        auto f = it->find(name);
+        if (f != it->end()) return f->second;
+    }
+    BOOST_ASSERT(false);  // variable not declared
+    return -1;
+}
+
+void PlnVCodeGen::declareVar(const string& name, VReg r)
+{
+    varScopes.back()[name] = r;
+}
+
+// -------- Utilities --------
+
 VReg PlnVCodeGen::allocVReg()
 {
     return nextVReg++;
@@ -27,11 +56,8 @@ void PlnVCodeGen::lowerCCCallExpr(const CCCallExpr& expr, VFunc& func)
             func.instrs.push_back(MovImm{r, VRegType::Int64, (long long)stoull(e->value)});
             args.push_back(r);
         } else if (auto* e = dynamic_cast<const IdExpr*>(arg.get())) {
-            auto it = localVarMap.find(e->name);
-            BOOST_ASSERT(it != localVarMap.end());
-            VReg r = allocVReg();
-            func.instrs.push_back(LoadFromStack{r, it->second.first, it->second.second});
-            args.push_back(r);
+            // Use the variable's VReg directly; RegAlloc decides its location.
+            args.push_back(findVar(e->name));
         } else {
             BOOST_ASSERT(false);  // not-impl
         }
@@ -60,12 +86,11 @@ void PlnVCodeGen::lowerExprStmt(const ExprStmt& stmt, VFunc& func)
 void PlnVCodeGen::lowerVarDeclStmt(const VarDeclStmt& stmt, VFunc& func)
 {
     for (auto& ve : stmt.vars) {
-        stackOffset -= 8;  // int64 = 8 bytes
-        localVarMap[ve.varName] = {VRegType::Int64, stackOffset};
-
+        VReg r = allocVReg();
+        declareVar(ve.varName, r);
         if (ve.init) {
             if (auto* e = dynamic_cast<const IntLitExpr*>(ve.init.get())) {
-                func.instrs.push_back(StoreImm{stoll(e->value), VRegType::Int64, stackOffset});
+                func.instrs.push_back(InitVar{r, VRegType::Int64, stoll(e->value)});
             } else {
                 BOOST_ASSERT(false);  // other init exprs: 0204+
             }
@@ -105,10 +130,11 @@ VProg PlnVCodeGen::generate(const Module& module)
     // Build _start function
     VFunc startFunc;
     startFunc.name = "_start";
+    enterVarScope();
     for (auto& stmt : module.statements) {
         lowerStmt(*stmt, startFunc);
     }
-    startFunc.frameSize = -stackOffset;
+    leaveVarScope();
     startFunc.instrs.push_back(ExitCode{0});
     prog.funcs.push_back(move(startFunc));
 

--- a/src/codegen/PlnVCodeGen.cpp
+++ b/src/codegen/PlnVCodeGen.cpp
@@ -39,28 +39,55 @@ VReg PlnVCodeGen::allocVReg()
 
 // -------- Lower AST to VInstr --------
 
+VReg PlnVCodeGen::lowerExpr(const Expr& expr, VFunc& func)
+{
+    switch (expr.kind) {
+        case ExprKind::StrLit: {
+            auto& e = static_cast<const StrLitExpr&>(expr);
+            VReg r = allocVReg();
+            func.instrs.push_back(LeaLabel{r, VRegType::Ptr64, strLiterals.at(e.value)});
+            return r;
+        }
+        case ExprKind::IntLit: {
+            auto& e = static_cast<const IntLitExpr&>(expr);
+            VReg r = allocVReg();
+            func.instrs.push_back(MovImm{r, VRegType::Int64, stoll(e.value)});
+            return r;
+        }
+        case ExprKind::UintLit: {
+            auto& e = static_cast<const UintLitExpr&>(expr);
+            VReg r = allocVReg();
+            func.instrs.push_back(MovImm{r, VRegType::Int64, (long long)stoull(e.value)});
+            return r;
+        }
+        case ExprKind::Id: {
+            auto& e = static_cast<const IdExpr&>(expr);
+            return findVar(e.name);
+        }
+        case ExprKind::Add: {
+            auto& e  = static_cast<const AddExpr&>(expr);
+            VReg l   = lowerExpr(*e.left, func);
+            VReg r   = lowerExpr(*e.right, func);
+            VReg dst = allocVReg();
+            func.instrs.push_back(Add{dst, l, r, VRegType::Int64});
+            return dst;
+        }
+        case ExprKind::CCCall:
+            lowerCCCallExpr(static_cast<const CCCallExpr&>(expr), func);
+            return -1;  // call expr: no result VReg
+        case ExprKind::PlnCall:
+            lowerPlnCallExpr(static_cast<const PlnCallExpr&>(expr), func);
+            return -1;
+    }
+    BOOST_ASSERT(false);  // unreachable
+    return -1;
+}
+
 void PlnVCodeGen::lowerCCCallExpr(const CCCallExpr& expr, VFunc& func)
 {
     vector<VReg> args;
     for (auto& arg : expr.args) {
-        if (auto* e = dynamic_cast<const StrLitExpr*>(arg.get())) {
-            VReg r = allocVReg();
-            func.instrs.push_back(LeaLabel{r, VRegType::Ptr64, strLiterals.at(e->value)});
-            args.push_back(r);
-        } else if (auto* e = dynamic_cast<const IntLitExpr*>(arg.get())) {
-            VReg r = allocVReg();
-            func.instrs.push_back(MovImm{r, VRegType::Int64, stoll(e->value)});
-            args.push_back(r);
-        } else if (auto* e = dynamic_cast<const UintLitExpr*>(arg.get())) {
-            VReg r = allocVReg();
-            func.instrs.push_back(MovImm{r, VRegType::Int64, (long long)stoull(e->value)});
-            args.push_back(r);
-        } else if (auto* e = dynamic_cast<const IdExpr*>(arg.get())) {
-            // Use the variable's VReg directly; RegAlloc decides its location.
-            args.push_back(findVar(e->name));
-        } else {
-            BOOST_ASSERT(false);  // not-impl
-        }
+        args.push_back(lowerExpr(*arg, func));
     }
     func.instrs.push_back(CallC{expr.name, move(args)});
 }
@@ -72,41 +99,37 @@ void PlnVCodeGen::lowerPlnCallExpr(const PlnCallExpr& expr, VFunc& func)
 
 void PlnVCodeGen::lowerExprStmt(const ExprStmt& stmt, VFunc& func)
 {
-    if (auto* e = dynamic_cast<const CCCallExpr*>(stmt.body.get())) {
-        lowerCCCallExpr(*e, func);
-        return;
-    }
-    if (auto* e = dynamic_cast<const PlnCallExpr*>(stmt.body.get())) {
-        lowerPlnCallExpr(*e, func);
-        return;
-    }
-    // other expression statements: not-impl
+    lowerExpr(*stmt.body, func);
 }
 
 void PlnVCodeGen::lowerVarDeclStmt(const VarDeclStmt& stmt, VFunc& func)
 {
     for (auto& ve : stmt.vars) {
-        VReg r = allocVReg();
-        declareVar(ve.varName, r);
+        VReg r;
         if (ve.init) {
-            if (auto* e = dynamic_cast<const IntLitExpr*>(ve.init.get())) {
-                func.instrs.push_back(InitVar{r, VRegType::Int64, stoll(e->value)});
+            if (ve.init->kind == ExprKind::IntLit) {
+                auto& e = static_cast<const IntLitExpr&>(*ve.init);
+                r = allocVReg();
+                func.instrs.push_back(InitVar{r, VRegType::Int64, stoll(e.value)});
             } else {
-                BOOST_ASSERT(false);  // other init exprs: 0204+
+                r = lowerExpr(*ve.init, func);
             }
+        } else {
+            r = allocVReg();
         }
+        declareVar(ve.varName, r);
     }
 }
 
 void PlnVCodeGen::lowerStmt(const Stmt& stmt, VFunc& func)
 {
-    if (auto* s = dynamic_cast<const ExprStmt*>(&stmt)) {
-        lowerExprStmt(*s, func);
-        return;
-    }
-    if (auto* s = dynamic_cast<const VarDeclStmt*>(&stmt)) {
-        lowerVarDeclStmt(*s, func);
-        return;
+    switch (stmt.kind) {
+        case StmtKind::Expr:
+            lowerExprStmt(static_cast<const ExprStmt&>(stmt), func);
+            return;
+        case StmtKind::VarDecl:
+            lowerVarDeclStmt(static_cast<const VarDeclStmt&>(stmt), func);
+            return;
     }
     BOOST_ASSERT(false);
 }

--- a/src/codegen/PlnVCodeGen.cpp
+++ b/src/codegen/PlnVCodeGen.cpp
@@ -12,23 +12,25 @@ VReg PlnVCodeGen::allocVReg()
 
 void PlnVCodeGen::lowerCCCallExpr(const CCCallExpr& expr, VFunc& func)
 {
-    int argCount = 0;
+    vector<VReg> args;
     for (auto& arg : expr.args) {
         if (auto* e = dynamic_cast<const StrLitExpr*>(arg.get())) {
             VReg r = allocVReg();
             func.instrs.push_back(LeaLabel{r, VRegType::Ptr64, strLiterals.at(e->value)});
+            args.push_back(r);
         } else if (auto* e = dynamic_cast<const IntLitExpr*>(arg.get())) {
             VReg r = allocVReg();
             func.instrs.push_back(MovImm{r, VRegType::Int64, stoll(e->value)});
+            args.push_back(r);
         } else if (auto* e = dynamic_cast<const UintLitExpr*>(arg.get())) {
             VReg r = allocVReg();
             func.instrs.push_back(MovImm{r, VRegType::Int64, (long long)stoull(e->value)});
+            args.push_back(r);
         } else {
             BOOST_ASSERT(false);  // not-impl
         }
-        ++argCount;
     }
-    func.instrs.push_back(CallC{expr.name, argCount});
+    func.instrs.push_back(CallC{expr.name, move(args)});
 }
 
 void PlnVCodeGen::lowerPlnCallExpr(const PlnCallExpr& expr, VFunc& func)

--- a/src/codegen/PlnVCodeGen.cpp
+++ b/src/codegen/PlnVCodeGen.cpp
@@ -26,6 +26,12 @@ void PlnVCodeGen::lowerCCCallExpr(const CCCallExpr& expr, VFunc& func)
             VReg r = allocVReg();
             func.instrs.push_back(MovImm{r, VRegType::Int64, (long long)stoull(e->value)});
             args.push_back(r);
+        } else if (auto* e = dynamic_cast<const IdExpr*>(arg.get())) {
+            auto it = localVarMap.find(e->name);
+            BOOST_ASSERT(it != localVarMap.end());
+            VReg r = allocVReg();
+            func.instrs.push_back(LoadFromStack{r, it->second.first, it->second.second});
+            args.push_back(r);
         } else {
             BOOST_ASSERT(false);  // not-impl
         }
@@ -51,10 +57,30 @@ void PlnVCodeGen::lowerExprStmt(const ExprStmt& stmt, VFunc& func)
     // other expression statements: not-impl
 }
 
+void PlnVCodeGen::lowerVarDeclStmt(const VarDeclStmt& stmt, VFunc& func)
+{
+    for (auto& ve : stmt.vars) {
+        stackOffset -= 8;  // int64 = 8 bytes
+        localVarMap[ve.varName] = {VRegType::Int64, stackOffset};
+
+        if (ve.init) {
+            if (auto* e = dynamic_cast<const IntLitExpr*>(ve.init.get())) {
+                func.instrs.push_back(StoreImm{stoll(e->value), VRegType::Int64, stackOffset});
+            } else {
+                BOOST_ASSERT(false);  // other init exprs: 0204+
+            }
+        }
+    }
+}
+
 void PlnVCodeGen::lowerStmt(const Stmt& stmt, VFunc& func)
 {
     if (auto* s = dynamic_cast<const ExprStmt*>(&stmt)) {
         lowerExprStmt(*s, func);
+        return;
+    }
+    if (auto* s = dynamic_cast<const VarDeclStmt*>(&stmt)) {
+        lowerVarDeclStmt(*s, func);
         return;
     }
     BOOST_ASSERT(false);
@@ -82,6 +108,7 @@ VProg PlnVCodeGen::generate(const Module& module)
     for (auto& stmt : module.statements) {
         lowerStmt(*stmt, startFunc);
     }
+    startFunc.frameSize = -stackOffset;
     startFunc.instrs.push_back(ExitCode{0});
     prog.funcs.push_back(move(startFunc));
 

--- a/src/codegen/PlnVCodeGen.cpp
+++ b/src/codegen/PlnVCodeGen.cpp
@@ -17,6 +17,12 @@ void PlnVCodeGen::lowerCCCallExpr(const CCCallExpr& expr, VFunc& func)
         if (auto* e = dynamic_cast<const StrLitExpr*>(arg.get())) {
             VReg r = allocVReg();
             func.instrs.push_back(LeaLabel{r, VRegType::Ptr64, strLiterals.at(e->value)});
+        } else if (auto* e = dynamic_cast<const IntLitExpr*>(arg.get())) {
+            VReg r = allocVReg();
+            func.instrs.push_back(MovImm{r, VRegType::Int64, stoll(e->value)});
+        } else if (auto* e = dynamic_cast<const UintLitExpr*>(arg.get())) {
+            VReg r = allocVReg();
+            func.instrs.push_back(MovImm{r, VRegType::Int64, (long long)stoull(e->value)});
         } else {
             BOOST_ASSERT(false);  // not-impl
         }

--- a/src/codegen/PlnVCodeGen.h
+++ b/src/codegen/PlnVCodeGen.h
@@ -6,20 +6,25 @@
 #pragma once
 #include <map>
 #include <string>
+#include <utility>
 #include "PlnNode.h"
 #include "PlnVProg.h"
 
 using std::map;
+using std::pair;
 using std::string;
 
 class PlnVCodeGen {
     map<string, string> strLiterals;  // value -> label
     int nextVReg = 0;
+    int stackOffset = 0;                           // current stack offset (negative)
+    map<string, pair<VRegType, int>> localVarMap;  // var name -> {type, offset}
 
     VReg allocVReg();
 
     void lowerStmt(const Stmt& stmt, VFunc& func);
     void lowerExprStmt(const ExprStmt& stmt, VFunc& func);
+    void lowerVarDeclStmt(const VarDeclStmt& stmt, VFunc& func);
     void lowerCCCallExpr(const CCCallExpr& expr, VFunc& func);
     void lowerPlnCallExpr(const PlnCallExpr& expr, VFunc& func);
 

--- a/src/codegen/PlnVCodeGen.h
+++ b/src/codegen/PlnVCodeGen.h
@@ -6,19 +6,25 @@
 #pragma once
 #include <map>
 #include <string>
-#include <utility>
+#include <vector>
 #include "PlnNode.h"
 #include "PlnVProg.h"
 
 using std::map;
-using std::pair;
 using std::string;
+using std::vector;
 
 class PlnVCodeGen {
     map<string, string> strLiterals;  // value -> label
     int nextVReg = 0;
-    int stackOffset = 0;                           // current stack offset (negative)
-    map<string, pair<VRegType, int>> localVarMap;  // var name -> {type, offset}
+
+    // Variable symbol table: scoped stack of name -> VReg mappings.
+    // enterVarScope/leaveVarScope push/pop; findVar searches from innermost.
+    vector<map<string, VReg>> varScopes;
+    void enterVarScope();
+    void leaveVarScope();
+    VReg findVar(const string& name) const;
+    void declareVar(const string& name, VReg r);
 
     VReg allocVReg();
 

--- a/src/codegen/PlnVCodeGen.h
+++ b/src/codegen/PlnVCodeGen.h
@@ -28,6 +28,7 @@ class PlnVCodeGen {
 
     VReg allocVReg();
 
+    VReg lowerExpr(const Expr& expr, VFunc& func);
     void lowerStmt(const Stmt& stmt, VFunc& func);
     void lowerExprStmt(const ExprStmt& stmt, VFunc& func);
     void lowerVarDeclStmt(const VarDeclStmt& stmt, VFunc& func);

--- a/src/codegen/PlnVProg.h
+++ b/src/codegen/PlnVProg.h
@@ -26,14 +26,13 @@ enum class VRegType {
 
 // -------- Virtual instructions --------
 
-struct LeaLabel      { VReg dst; VRegType type; string label; };       // dst = address of label
-struct MovImm        { VReg dst; VRegType type; long long value; };    // dst = immediate integer
-struct CallC         { string name; vector<VReg> args; };
-struct ExitCode      { int code; };
-struct StoreImm      { long long value; VRegType type; int offset; };  // movq $v, offset(%rbp)
-struct LoadFromStack { VReg dst; VRegType type; int offset; };         // movq offset(%rbp), reg
+struct LeaLabel { VReg dst; VRegType type; string label; };       // dst = address of label
+struct MovImm   { VReg dst; VRegType type; long long value; };    // dst = immediate integer
+struct InitVar  { VReg dst; VRegType type; long long imm; };      // variable init: dst_vreg = imm
+struct CallC    { string name; vector<VReg> args; };
+struct ExitCode { int code; };
 
-using VInstr = std::variant<LeaLabel, MovImm, CallC, ExitCode, StoreImm, LoadFromStack>;
+using VInstr = std::variant<LeaLabel, MovImm, InitVar, CallC, ExitCode>;
 
 // -------- Program structure --------
 
@@ -44,7 +43,6 @@ struct VStringLiteral {
 
 struct VFunc {
     string name;
-    int    frameSize = 0;  // local var bytes (>0 → prologue required)
     vector<VInstr> instrs;
 };
 

--- a/src/codegen/PlnVProg.h
+++ b/src/codegen/PlnVProg.h
@@ -26,11 +26,12 @@ enum class VRegType {
 
 // -------- Virtual instructions --------
 
-struct LeaLabel { VReg dst; VRegType type; string label; };  // dst = address of label
+struct LeaLabel { VReg dst; VRegType type; string label; };       // dst = address of label
+struct MovImm   { VReg dst; VRegType type; long long value; };    // dst = immediate integer
 struct CallC    { string name; int argCount; };
 struct ExitCode { int code; };
 
-using VInstr = std::variant<LeaLabel, CallC, ExitCode>;
+using VInstr = std::variant<LeaLabel, MovImm, CallC, ExitCode>;
 
 // -------- Program structure --------
 

--- a/src/codegen/PlnVProg.h
+++ b/src/codegen/PlnVProg.h
@@ -28,7 +28,7 @@ enum class VRegType {
 
 struct LeaLabel { VReg dst; VRegType type; string label; };       // dst = address of label
 struct MovImm   { VReg dst; VRegType type; long long value; };    // dst = immediate integer
-struct CallC    { string name; int argCount; };
+struct CallC    { string name; vector<VReg> args; };
 struct ExitCode { int code; };
 
 using VInstr = std::variant<LeaLabel, MovImm, CallC, ExitCode>;

--- a/src/codegen/PlnVProg.h
+++ b/src/codegen/PlnVProg.h
@@ -26,12 +26,14 @@ enum class VRegType {
 
 // -------- Virtual instructions --------
 
-struct LeaLabel { VReg dst; VRegType type; string label; };       // dst = address of label
-struct MovImm   { VReg dst; VRegType type; long long value; };    // dst = immediate integer
-struct CallC    { string name; vector<VReg> args; };
-struct ExitCode { int code; };
+struct LeaLabel      { VReg dst; VRegType type; string label; };       // dst = address of label
+struct MovImm        { VReg dst; VRegType type; long long value; };    // dst = immediate integer
+struct CallC         { string name; vector<VReg> args; };
+struct ExitCode      { int code; };
+struct StoreImm      { long long value; VRegType type; int offset; };  // movq $v, offset(%rbp)
+struct LoadFromStack { VReg dst; VRegType type; int offset; };         // movq offset(%rbp), reg
 
-using VInstr = std::variant<LeaLabel, MovImm, CallC, ExitCode>;
+using VInstr = std::variant<LeaLabel, MovImm, CallC, ExitCode, StoreImm, LoadFromStack>;
 
 // -------- Program structure --------
 
@@ -42,6 +44,7 @@ struct VStringLiteral {
 
 struct VFunc {
     string name;
+    int    frameSize = 0;  // local var bytes (>0 → prologue required)
     vector<VInstr> instrs;
 };
 

--- a/src/codegen/PlnVProg.h
+++ b/src/codegen/PlnVProg.h
@@ -29,10 +29,11 @@ enum class VRegType {
 struct LeaLabel { VReg dst; VRegType type; string label; };       // dst = address of label
 struct MovImm   { VReg dst; VRegType type; long long value; };    // dst = immediate integer
 struct InitVar  { VReg dst; VRegType type; long long imm; };      // variable init: dst_vreg = imm
+struct Add      { VReg dst; VReg lhs; VReg rhs; VRegType type; }; // dst = lhs + rhs
 struct CallC    { string name; vector<VReg> args; };
 struct ExitCode { int code; };
 
-using VInstr = std::variant<LeaLabel, MovImm, InitVar, CallC, ExitCode>;
+using VInstr = std::variant<LeaLabel, MovImm, InitVar, Add, CallC, ExitCode>;
 
 // -------- Program structure --------
 

--- a/src/codegen/PlnX86CodeGen.cpp
+++ b/src/codegen/PlnX86CodeGen.cpp
@@ -80,6 +80,9 @@ void PlnX86CodeGen::emit(const VProg& prog)
             if (auto* i = std::get_if<LeaLabel>(&instr)) {
                 const PhysLoc& loc = rm.at(i->dst);
                 emitLeaLabel(sizedRegName(loc.base, loc.type), i->label);
+            } else if (auto* i = std::get_if<MovImm>(&instr)) {
+                const PhysLoc& loc = rm.at(i->dst);
+                emitMovImm(loc.base, i->value);
             } else if (auto* i = std::get_if<CallC>(&instr)) {
                 emitCallC(i->name, i->argCount);
             } else if (auto* i = std::get_if<ExitCode>(&instr)) {
@@ -123,6 +126,11 @@ void PlnX86CodeGen::emitStringLiteral(const string& label, const string& value)
 void PlnX86CodeGen::emitLeaLabel(const string& reg, const string& label)
 {
     out << "\tleaq " << label << "(%rip), " << reg << "\n";
+}
+
+void PlnX86CodeGen::emitMovImm(const string& reg, long long value)
+{
+    out << "\tmovq $" << value << ", " << reg << "\n";
 }
 
 void PlnX86CodeGen::emitCallC(const string& name, int argCount)

--- a/src/codegen/PlnX86CodeGen.cpp
+++ b/src/codegen/PlnX86CodeGen.cpp
@@ -57,7 +57,8 @@ static string sizedRegName(const string& base, VRegType type)
 // x86-64 System V ABI physical register lists
 static const PhysRegs x86PhysRegs = {
     { "%rdi", "%rsi", "%rdx", "%rcx", "%r8", "%r9" },
-    { "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm5", "%xmm6", "%xmm7" }
+    { "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm5", "%xmm6", "%xmm7" },
+    { "%rbx", "%r12", "%r13", "%r14", "%r15" }
 };
 
 void PlnX86CodeGen::emit(const VProg& prog)
@@ -84,7 +85,14 @@ void PlnX86CodeGen::emit(const VProg& prog)
                 const PhysLoc& loc = rm.at(i->dst);
                 emitMovImm(loc.base, i->value);
             } else if (auto* i = std::get_if<CallC>(&instr)) {
-                emitCallC(i->name, i->argCount);
+                for (int j = 0; j < (int)i->args.size(); j++) {
+                    const PhysLoc& loc = rm.at(i->args[j]);
+                    const string& dst = x86PhysRegs.intArgs[j];
+                    if (loc.base != dst) {
+                        out << "\tmovq " << loc.base << ", " << dst << "\n";
+                    }
+                }
+                emitCallC(i->name);
             } else if (auto* i = std::get_if<ExitCode>(&instr)) {
                 emitExit(i->code);
             }
@@ -133,9 +141,8 @@ void PlnX86CodeGen::emitMovImm(const string& reg, long long value)
     out << "\tmovq $" << value << ", " << reg << "\n";
 }
 
-void PlnX86CodeGen::emitCallC(const string& name, int argCount)
+void PlnX86CodeGen::emitCallC(const string& name)
 {
-    (void)argCount;
     // For variadic C functions, al = number of floating-point args (0 here)
     out << "\txorl %eax, %eax\n";
     out << "\tcall " << name << "\n";

--- a/src/codegen/PlnX86CodeGen.cpp
+++ b/src/codegen/PlnX86CodeGen.cpp
@@ -54,6 +54,16 @@ static string sizedRegName(const string& base, VRegType type)
     return base;  // fallback
 }
 
+// Return the AT&T source operand string for a PhysLoc:
+//   stack  → "-8(%rbp)"  (memory reference)
+//   reg    → "%rsi"      (sized register name)
+static string srcOperand(const PhysLoc& loc)
+{
+    if (loc.isStack())
+        return std::to_string(loc.stackOffset) + "(%rbp)";
+    return sizedRegName(loc.base, loc.type);
+}
+
 // x86-64 System V ABI physical register lists
 static const PhysRegs x86PhysRegs = {
     { "%rdi", "%rsi", "%rdx", "%rcx", "%r8", "%r9" },
@@ -98,15 +108,19 @@ void PlnX86CodeGen::emit(const VProg& prog)
                 } else {
                     out << "\tmovq $" << i->imm << ", " << sizedRegName(loc.base, loc.type) << "\n";
                 }
+            } else if (auto* a = std::get_if<Add>(&instr)) {
+                if (!rm.count(a->dst)) continue;  // dead: result never used
+                const PhysLoc& dst_loc = rm.at(a->dst);
+                BOOST_ASSERT(!dst_loc.isStack());  // dst must be in a register
+                string dst_reg = sizedRegName(dst_loc.base, dst_loc.type);
+                out << "\tmovq " << srcOperand(rm.at(a->lhs)) << ", " << dst_reg << "\n";
+                out << "\taddq " << srcOperand(rm.at(a->rhs)) << ", " << dst_reg << "\n";
             } else if (auto* i = std::get_if<CallC>(&instr)) {
                 for (int j = 0; j < (int)i->args.size(); j++) {
-                    const PhysLoc& loc = rm.at(i->args[j]);
                     const string& dst = x86PhysRegs.intArgs[j];
-                    if (loc.isStack()) {
-                        out << "\tmovq " << loc.stackOffset << "(%rbp), " << dst << "\n";
-                    } else if (loc.base != dst) {
-                        out << "\tmovq " << loc.base << ", " << dst << "\n";
-                    }
+                    string src = srcOperand(rm.at(i->args[j]));
+                    if (src != dst)
+                        out << "\tmovq " << src << ", " << dst << "\n";
                 }
                 emitCallC(i->name);
             } else if (auto* i = std::get_if<ExitCode>(&instr)) {

--- a/src/codegen/PlnX86CodeGen.cpp
+++ b/src/codegen/PlnX86CodeGen.cpp
@@ -75,12 +75,13 @@ void PlnX86CodeGen::emit(const VProg& prog)
         emitGlobal(func.name);
         emitLabel(func.name);
 
-        RegMap rm = allocateRegisters(func, x86PhysRegs);
+        RegAllocResult ra = allocateRegisters(func, x86PhysRegs);
+        const RegMap& rm  = ra.regMap;
 
-        if (func.frameSize > 0) {
+        if (ra.frameSize > 0) {
             out << "\tpushq %rbp\n";
             out << "\tmovq %rsp, %rbp\n";
-            out << "\tsubq $" << func.frameSize << ", %rsp\n";
+            out << "\tsubq $" << ra.frameSize << ", %rsp\n";
         }
 
         for (auto& instr : func.instrs) {
@@ -90,22 +91,26 @@ void PlnX86CodeGen::emit(const VProg& prog)
             } else if (auto* i = std::get_if<MovImm>(&instr)) {
                 const PhysLoc& loc = rm.at(i->dst);
                 emitMovImm(loc.base, i->value);
+            } else if (auto* i = std::get_if<InitVar>(&instr)) {
+                const PhysLoc& loc = rm.at(i->dst);
+                if (loc.isStack()) {
+                    out << "\tmovq $" << i->imm << ", " << loc.stackOffset << "(%rbp)\n";
+                } else {
+                    out << "\tmovq $" << i->imm << ", " << sizedRegName(loc.base, loc.type) << "\n";
+                }
             } else if (auto* i = std::get_if<CallC>(&instr)) {
                 for (int j = 0; j < (int)i->args.size(); j++) {
                     const PhysLoc& loc = rm.at(i->args[j]);
                     const string& dst = x86PhysRegs.intArgs[j];
-                    if (loc.base != dst) {
+                    if (loc.isStack()) {
+                        out << "\tmovq " << loc.stackOffset << "(%rbp), " << dst << "\n";
+                    } else if (loc.base != dst) {
                         out << "\tmovq " << loc.base << ", " << dst << "\n";
                     }
                 }
                 emitCallC(i->name);
             } else if (auto* i = std::get_if<ExitCode>(&instr)) {
                 emitExit(i->code);
-            } else if (auto* i = std::get_if<StoreImm>(&instr)) {
-                out << "\tmovq $" << i->value << ", " << i->offset << "(%rbp)\n";
-            } else if (auto* i = std::get_if<LoadFromStack>(&instr)) {
-                const PhysLoc& loc = rm.at(i->dst);
-                out << "\tmovq " << i->offset << "(%rbp), " << sizedRegName(loc.base, loc.type) << "\n";
             }
         }
     }

--- a/src/codegen/PlnX86CodeGen.cpp
+++ b/src/codegen/PlnX86CodeGen.cpp
@@ -77,6 +77,12 @@ void PlnX86CodeGen::emit(const VProg& prog)
 
         RegMap rm = allocateRegisters(func, x86PhysRegs);
 
+        if (func.frameSize > 0) {
+            out << "\tpushq %rbp\n";
+            out << "\tmovq %rsp, %rbp\n";
+            out << "\tsubq $" << func.frameSize << ", %rsp\n";
+        }
+
         for (auto& instr : func.instrs) {
             if (auto* i = std::get_if<LeaLabel>(&instr)) {
                 const PhysLoc& loc = rm.at(i->dst);
@@ -95,6 +101,11 @@ void PlnX86CodeGen::emit(const VProg& prog)
                 emitCallC(i->name);
             } else if (auto* i = std::get_if<ExitCode>(&instr)) {
                 emitExit(i->code);
+            } else if (auto* i = std::get_if<StoreImm>(&instr)) {
+                out << "\tmovq $" << i->value << ", " << i->offset << "(%rbp)\n";
+            } else if (auto* i = std::get_if<LoadFromStack>(&instr)) {
+                const PhysLoc& loc = rm.at(i->dst);
+                out << "\tmovq " << i->offset << "(%rbp), " << sizedRegName(loc.base, loc.type) << "\n";
             }
         }
     }

--- a/src/codegen/PlnX86CodeGen.h
+++ b/src/codegen/PlnX86CodeGen.h
@@ -17,7 +17,7 @@ class PlnX86CodeGen : public PlnCodeGen {
     void emitStringLiteral(const string& label, const string& value);
     void emitLeaLabel(const string& reg, const string& label);
     void emitMovImm(const string& reg, long long value);
-    void emitCallC(const string& name, int argCount);
+    void emitCallC(const string& name);
     void emitExit(int code);
 
 public:

--- a/src/codegen/PlnX86CodeGen.h
+++ b/src/codegen/PlnX86CodeGen.h
@@ -16,6 +16,7 @@ class PlnX86CodeGen : public PlnCodeGen {
     void emitLabel(const string& name);
     void emitStringLiteral(const string& label, const string& value);
     void emitLeaLabel(const string& reg, const string& label);
+    void emitMovImm(const string& reg, long long value);
     void emitCallC(const string& name, int argCount);
     void emitExit(int code);
 

--- a/src/gen-ast/PlnParser.yy
+++ b/src/gen-ast/PlnParser.yy
@@ -128,6 +128,10 @@ class PlnLexer;
 %type <string>	import_as
 %type <json>	expression func_call term
 %type <vector<json>>	arguments
+%type <string>	var_type var_prefix
+%type <bool>	var_postfix
+%type <json>	var_declaration
+%type <vector<json>>	var_declarations
 
 %left ARROW DBL_ARROW
 %left '<' '>' OPE_LE OPE_GE
@@ -175,8 +179,15 @@ statement: import ';'
 	}
 	| var_declarations ';'
 	{
-		json temp = {{"stmt-type", "not-impl"}};
-		$$ = move(temp);
+		bool all_ok = true;
+		for (auto& v : $1) {
+			if (v.count("not-impl")) { all_ok = false; break; }
+		}
+		if (all_ok) {
+			$$ = {{"stmt-type", "var-decl"}, {"vars", move($1)}};
+		} else {
+			$$ = {{"stmt-type", "not-impl"}};
+		}
 	}
 	| const_decl ';'
 	{
@@ -301,13 +312,27 @@ block: '{' statements '}'
 	;
 
 var_declarations: var_declaration
+	{ $$ = { $1 }; }
 	| var_declarations ',' var_declaration
+	{ $$ = move($1); $$.push_back($3); }
 	;
 
 var_declaration: var_type move_owner_r var_prefix ID var_postfix
+	{ $$ = {{"not-impl", true}}; }
 	| var_type var_prefix ID var_postfix '=' expression
+	{
+		if (!$1.empty() && $2.empty() && !$4) {
+			$$ = { {"var-name", $3},
+			       {"var-type", {{"type-kind", "prim"}, {"type-name", $1}}},
+			       {"init",     $6} };
+		} else {
+			$$ = {{"not-impl", true}};
+		}
+	}
 	| var_prefix ID var_postfix '=' expression
+	{ $$ = {{"not-impl", true}}; }
 	| tapple_decl '=' expression
+	{ $$ = {{"not-impl", true}}; }
 	;
 
 tapple_decl: '(' tapple_decl_inner ')'
@@ -497,7 +522,9 @@ expressions: expression
 	;
 
 var_type: ID
+	{ $$ = $1; }
 	| ID '<' temp_ids '>'
+	{ $$ = ""; }
 	;
 
 temp_ids: ID | temp_ids ',' ID
@@ -513,10 +540,14 @@ do_export: /* empty */ | KW_EXPORT
 move_owner_r:	/* empty */ | DBL_GRTR
 	;
 
-var_prefix:	/* empty */ | '@' | '$' | AT_EXCL
+var_prefix:	/* empty */ { $$ = ""; }
+	| '@'      { $$ = "@"; }
+	| '$'      { $$ = "$"; }
+	| AT_EXCL  { $$ = "@!"; }
 	;
 
-var_postfix: /* empty */ | array_postfix
+var_postfix: /* empty */   { $$ = false; }
+	| array_postfix        { $$ = true; }
 	;
 
 array_postfix: '[' array_type emitable_exps ']' var_prefix

--- a/src/gen-ast/PlnParser.yy
+++ b/src/gen-ast/PlnParser.yy
@@ -394,7 +394,7 @@ expression: term
 	| dict_desc
 	{ $$ = {{"expr-type", "not-impl"}}; }
 	| expression '+' expression
-	{ $$ = {{"expr-type", "not-impl"}}; }
+	{ $$ = {{"expr-type", "add"}, {"left", $1}, {"right", $3}}; }
 	| expression '-' expression
 	{ $$ = {{"expr-type", "not-impl"}}; }
 	| expression '*' expression

--- a/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
+++ b/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
@@ -82,6 +82,9 @@ json PlnSemanticAnalyzer::sa_expression(const json &expr)
 		if (it != varSymbolTable.end()) {
 			sa_expr["var-type"] = it->second;
 		}
+	} else if (expr_type == "add") {
+		sa_expr["left"]  = sa_expression(expr["left"]);
+		sa_expr["right"] = sa_expression(expr["right"]);
 	} else if (expr_type == "call") {
 		if (findCFunction(expr["name"])) {
 			sa_expr["func-type"] = "c";

--- a/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
+++ b/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
@@ -55,6 +55,8 @@ void PlnSemanticAnalyzer::sa_statements(const json &stmts)
 			sa_cinclude(stmt);
 		} else if (stmt_type == "expr") {
 			sa_expression_stmt(stmt);
+		} else if (stmt_type == "var-decl") {
+			sa_var_decl(stmt);
 		} else if (stmt_type == "not-impl") {
 			sa["statements"].push_back(stmt);
 		} else {
@@ -74,6 +76,11 @@ json PlnSemanticAnalyzer::sa_expression(const json &expr)
 			string label = ".str" + to_string(strLiteralLabels.size());
 			strLiteralLabels[value] = label;
 			sa["str-literals"].push_back({{"label", label}, {"value", value}});
+		}
+	} else if (expr_type == "id") {
+		auto it = varSymbolTable.find(expr["name"].get<string>());
+		if (it != varSymbolTable.end()) {
+			sa_expr["var-type"] = it->second;
 		}
 	} else if (expr_type == "call") {
 		if (findCFunction(expr["name"])) {
@@ -95,6 +102,22 @@ void PlnSemanticAnalyzer::sa_expression_stmt(const json &stmt)
 		{"stmt-type", "expr"},
 		{"body", sa_expression(stmt["body"])}
 	};
+	sa["statements"].push_back(sa_stmt);
+}
+
+void PlnSemanticAnalyzer::sa_var_decl(const json &stmt)
+{
+	json sa_stmt = {{"stmt-type", "var-decl"}, {"vars", json::array()}};
+	for (auto& var : stmt["vars"]) {
+		string name = var["var-name"];
+		varSymbolTable[name] = var["var-type"];
+
+		json sa_var = var;
+		if (var.contains("init")) {
+			sa_var["init"] = sa_expression(var["init"]);
+		}
+		sa_stmt["vars"].push_back(sa_var);
+	}
 	sa["statements"].push_back(sa_stmt);
 }
 

--- a/src/semantic-anlyzr/PlnSemanticAnalyzer.h
+++ b/src/semantic-anlyzr/PlnSemanticAnalyzer.h
@@ -20,6 +20,7 @@ class PlnSemanticAnalyzer {
 	json sa;
 	vector<map<string, json>> cFunctionScopes;
 	map<string, string> strLiteralLabels;  // value -> label
+	map<string, json> varSymbolTable;      // var name -> var-type
 
 	void pushScope();
 	void popScope();
@@ -30,6 +31,7 @@ class PlnSemanticAnalyzer {
 	void sa_cinclude(const json &stmt);
 	json sa_expression(const json &expr);
 	void sa_expression_stmt(const json &stmt);
+	void sa_var_decl(const json &stmt);
 
 public:
 	PlnSemanticAnalyzer(string base_path, string ast_filename, string c2ast_path);

--- a/test/build-mgr-tester/basicTests.cpp
+++ b/test/build-mgr-tester/basicTests.cpp
@@ -7,31 +7,19 @@ using namespace std;
 
 TEST(build_mgr, helloworld) {
 	cleanTestEnv();
-
 	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/001_helloworld.pa");
-	ASSERT_EQ(output, "");
-
-	output = execTestCommand("./a.out");
 	ASSERT_EQ(output, "Hello World!\n");
 }
 
 TEST(build_mgr, var_decl) {
 	cleanTestEnv();
-
 	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/002_var_decl.pa");
-	ASSERT_EQ(output, "");
-
-	output = execTestCommand("./a.out");
 	ASSERT_EQ(output, "10\n");
 }
 
 TEST(build_mgr, addition) {
 	cleanTestEnv();
-
 	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/003_addition.pa");
-	ASSERT_EQ(output, "");
-
-	output = execTestCommand("./a.out");
 	ASSERT_EQ(output, "30\n");
 }
 

--- a/test/build-mgr-tester/basicTests.cpp
+++ b/test/build-mgr-tester/basicTests.cpp
@@ -25,6 +25,16 @@ TEST(build_mgr, var_decl) {
 	ASSERT_EQ(output, "10\n");
 }
 
+TEST(build_mgr, addition) {
+	cleanTestEnv();
+
+	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/003_addition.pa");
+	ASSERT_EQ(output, "");
+
+	output = execTestCommand("./a.out");
+	ASSERT_EQ(output, "30\n");
+}
+
 TEST(build_mgr, clean) {
 	cleanTestEnv();
 

--- a/test/build-mgr-tester/basicTests.cpp
+++ b/test/build-mgr-tester/basicTests.cpp
@@ -15,6 +15,16 @@ TEST(build_mgr, helloworld) {
 	ASSERT_EQ(output, "Hello World!\n");
 }
 
+TEST(build_mgr, var_decl) {
+	cleanTestEnv();
+
+	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/002_var_decl.pa");
+	ASSERT_EQ(output, "");
+
+	output = execTestCommand("./a.out");
+	ASSERT_EQ(output, "10\n");
+}
+
 TEST(build_mgr, clean) {
 	cleanTestEnv();
 

--- a/test/codegen-tester/basicTests.cpp
+++ b/test/codegen-tester/basicTests.cpp
@@ -53,6 +53,21 @@ TEST(codegen, two_calls_arg_registers) {
     ASSERT_NE(asm_text.find("call printf"),  string::npos);
 }
 
+TEST(codegen, var_decl_init) {
+    cleanTestEnv();
+    string sa   = "../test/testdata/codegen/004_var_decl.sa.json";
+    string asmf = "out/004_var_decl.s";
+
+    string err = run_codegen(sa, asmf);
+    ASSERT_EQ(err, "");
+
+    string asm_text = readFile(asmf);
+    ASSERT_NE(asm_text.find("pushq %rbp"),         string::npos);
+    ASSERT_NE(asm_text.find("movq %rsp, %rbp"),    string::npos);
+    ASSERT_NE(asm_text.find("subq $"),             string::npos);
+    ASSERT_NE(asm_text.find("movq $10, -8(%rbp)"), string::npos);
+}
+
 TEST(codegen, helloworld_asm_output) {
     cleanTestEnv();
     string sa   = "../test/testdata/codegen/001_helloworld.sa.json";

--- a/test/codegen-tester/basicTests.cpp
+++ b/test/codegen-tester/basicTests.cpp
@@ -18,6 +18,21 @@ static string readFile(const string& path)
     return ss.str();
 }
 
+TEST(codegen, printf_int_literal) {
+    cleanTestEnv();
+    string sa   = "../test/testdata/codegen/002_printf_int_literal.sa.json";
+    string asmf = "out/002_printf_int_literal.s";
+
+    string err = run_codegen(sa, asmf);
+    ASSERT_EQ(err, "");
+
+    string asm_text = readFile(asmf);
+    ASSERT_NE(asm_text.find("movq $42,"),    string::npos);
+    ASSERT_NE(asm_text.find("%rdi"),         string::npos);
+    ASSERT_NE(asm_text.find("%rsi"),         string::npos);
+    ASSERT_NE(asm_text.find("call printf"),  string::npos);
+}
+
 TEST(codegen, helloworld_asm_output) {
     cleanTestEnv();
     string sa   = "../test/testdata/codegen/001_helloworld.sa.json";

--- a/test/codegen-tester/basicTests.cpp
+++ b/test/codegen-tester/basicTests.cpp
@@ -62,10 +62,9 @@ TEST(codegen, var_decl_init) {
     ASSERT_EQ(err, "");
 
     string asm_text = readFile(asmf);
-    ASSERT_NE(asm_text.find("pushq %rbp"),         string::npos);
-    ASSERT_NE(asm_text.find("movq %rsp, %rbp"),    string::npos);
-    ASSERT_NE(asm_text.find("subq $"),             string::npos);
-    ASSERT_NE(asm_text.find("movq $10, -8(%rbp)"), string::npos);
+    // x is initialized with 10 and passed to printf
+    ASSERT_NE(asm_text.find("movq $10,"),       string::npos);
+    ASSERT_NE(asm_text.find("call printf"),     string::npos);
 }
 
 TEST(codegen, helloworld_asm_output) {

--- a/test/codegen-tester/basicTests.cpp
+++ b/test/codegen-tester/basicTests.cpp
@@ -67,6 +67,20 @@ TEST(codegen, var_decl_init) {
     ASSERT_NE(asm_text.find("call printf"),     string::npos);
 }
 
+TEST(codegen, addition) {
+    cleanTestEnv();
+    string sa   = "../test/testdata/codegen/005_addition.sa.json";
+    string asmf = "out/005_addition.s";
+
+    string err = run_codegen(sa, asmf);
+    ASSERT_EQ(err, "");
+
+    string asm_text = readFile(asmf);
+    ASSERT_NE(asm_text.find("movq"),       string::npos);
+    ASSERT_NE(asm_text.find("addq"),       string::npos);
+    ASSERT_NE(asm_text.find("call printf"), string::npos);
+}
+
 TEST(codegen, helloworld_asm_output) {
     cleanTestEnv();
     string sa   = "../test/testdata/codegen/001_helloworld.sa.json";

--- a/test/codegen-tester/basicTests.cpp
+++ b/test/codegen-tester/basicTests.cpp
@@ -33,6 +33,26 @@ TEST(codegen, printf_int_literal) {
     ASSERT_NE(asm_text.find("call printf"),  string::npos);
 }
 
+// Verify that two sequential C calls each get correct argument registers.
+// This exercises the multi-call path with the vector<VReg> CallC design.
+// (Callee-saved register allocation is tested in the variable declaration tests.)
+TEST(codegen, two_calls_arg_registers) {
+    cleanTestEnv();
+    string sa   = "../test/testdata/codegen/003_two_calls.sa.json";
+    string asmf = "out/003_two_calls.s";
+
+    string err = run_codegen(sa, asmf);
+    ASSERT_EQ(err, "");
+
+    string asm_text = readFile(asmf);
+    // puts call: only %rdi
+    ASSERT_NE(asm_text.find("call puts"),    string::npos);
+    // printf call: %rdi (format) and %rsi (integer 99)
+    ASSERT_NE(asm_text.find("movq $99,"),    string::npos);
+    ASSERT_NE(asm_text.find("%rsi"),         string::npos);
+    ASSERT_NE(asm_text.find("call printf"),  string::npos);
+}
+
 TEST(codegen, helloworld_asm_output) {
     cleanTestEnv();
     string sa   = "../test/testdata/codegen/001_helloworld.sa.json";

--- a/test/gen-ast-tester/basicTests.cpp
+++ b/test/gen-ast-tester/basicTests.cpp
@@ -53,6 +53,29 @@ TEST(gen_ast, cinclude_functions_in_ast) {
 	ASSERT_TRUE(found_printf);
 }
 
+TEST(gen_ast, addition) {
+	cleanTestEnv();
+	string output = execTestCommand("bin/palan-gen-ast ../test/testdata/build-mgr/003_addition.pa");
+	ASSERT_TRUE(checkerr(output));
+	json jout = json::parse(output);
+
+	bool found = false;
+	for (auto& stmt : jout["ast"]["statements"]) {
+		if (stmt["stmt-type"] != "expr") continue;
+		auto& body = stmt["body"];
+		if (body["expr-type"] == "call" && body["name"] == "printf") {
+			for (auto& arg : body["args"]) {
+				if (arg["expr-type"] == "add") {
+					ASSERT_EQ(arg["left"]["expr-type"],  "id");
+					ASSERT_EQ(arg["right"]["expr-type"], "id");
+					found = true;
+				}
+			}
+		}
+	}
+	ASSERT_TRUE(found);
+}
+
 TEST(gen_ast, cli_tests) {
 	cleanTestEnv();
 	string output = execTestCommand("bin/palan-gen-ast -h");

--- a/test/sa-tester/basicTests.cpp
+++ b/test/sa-tester/basicTests.cpp
@@ -54,6 +54,25 @@ TEST(sa, str_literals_collected) {
 	ASSERT_EQ(lits[0]["label"], ".str0");
 }
 
+TEST(sa, var_decl_emitted) {
+	cleanTestEnv();
+	json jout = run_sa("../test/testdata/build-mgr/002_var_decl.pa");
+
+	ASSERT_TRUE(jout.is_object());
+	bool found = false;
+	for (auto& stmt : jout["statements"]) {
+		if (stmt["stmt-type"] != "var-decl") continue;
+		for (auto& v : stmt["vars"]) {
+			if (v["var-name"] == "x" && v["var-type"]["type-name"] == "int64") {
+				ASSERT_EQ(v["init"]["expr-type"], "lit-int");
+				ASSERT_EQ(v["init"]["value"],     "10");
+				found = true;
+			}
+		}
+	}
+	ASSERT_TRUE(found);
+}
+
 TEST(sa, cinclude_not_in_output) {
 	cleanTestEnv();
 	json jout = run_sa("../test/testdata/build-mgr/001_helloworld.pa");

--- a/test/sa-tester/basicTests.cpp
+++ b/test/sa-tester/basicTests.cpp
@@ -73,6 +73,29 @@ TEST(sa, var_decl_emitted) {
 	ASSERT_TRUE(found);
 }
 
+TEST(sa, addition) {
+	cleanTestEnv();
+	json jout = run_sa("../test/testdata/build-mgr/003_addition.pa");
+
+	ASSERT_TRUE(jout.is_object());
+
+	bool found = false;
+	for (auto& stmt : jout["statements"]) {
+		if (stmt["stmt-type"] != "expr") continue;
+		auto& body = stmt["body"];
+		if (body["expr-type"] == "call" && body["name"] == "printf") {
+			for (auto& arg : body["args"]) {
+				if (arg["expr-type"] == "add") {
+					ASSERT_EQ(arg["left"]["expr-type"],  "id");
+					ASSERT_EQ(arg["right"]["expr-type"], "id");
+					found = true;
+				}
+			}
+		}
+	}
+	ASSERT_TRUE(found);
+}
+
 TEST(sa, cinclude_not_in_output) {
 	cleanTestEnv();
 	json jout = run_sa("../test/testdata/build-mgr/001_helloworld.pa");

--- a/test/testdata/build-mgr/002_var_decl.pa
+++ b/test/testdata/build-mgr/002_var_decl.pa
@@ -1,0 +1,3 @@
+cinclude <stdio.h>;
+int64 x = 10;
+printf("%lld\n", x);

--- a/test/testdata/build-mgr/003_addition.pa
+++ b/test/testdata/build-mgr/003_addition.pa
@@ -1,0 +1,4 @@
+cinclude <stdio.h>;
+int64 x = 10;
+int64 y = 20;
+printf("%lld\n", x + y);

--- a/test/testdata/codegen/002_printf_int_literal.sa.json
+++ b/test/testdata/codegen/002_printf_int_literal.sa.json
@@ -1,0 +1,20 @@
+{
+  "original": "/test/printf_int_literal.pa",
+  "str-literals": [
+    {"label": ".str0", "value": "%d\n"}
+  ],
+  "statements": [
+    {
+      "stmt-type": "expr",
+      "body": {
+        "expr-type": "call",
+        "func-type": "c",
+        "name": "printf",
+        "args": [
+          {"expr-type": "lit-str", "value": "%d\n"},
+          {"expr-type": "lit-int", "value": "42"}
+        ]
+      }
+    }
+  ]
+}

--- a/test/testdata/codegen/003_two_calls.sa.json
+++ b/test/testdata/codegen/003_two_calls.sa.json
@@ -1,0 +1,32 @@
+{
+  "original": "/test/two_calls.pa",
+  "str-literals": [
+    {"label": ".str0", "value": "start\n"},
+    {"label": ".str1", "value": "%d\n"}
+  ],
+  "statements": [
+    {
+      "stmt-type": "expr",
+      "body": {
+        "expr-type": "call",
+        "func-type": "c",
+        "name": "puts",
+        "args": [
+          {"expr-type": "lit-str", "value": "start\n"}
+        ]
+      }
+    },
+    {
+      "stmt-type": "expr",
+      "body": {
+        "expr-type": "call",
+        "func-type": "c",
+        "name": "printf",
+        "args": [
+          {"expr-type": "lit-str", "value": "%d\n"},
+          {"expr-type": "lit-int", "value": "99"}
+        ]
+      }
+    }
+  ]
+}

--- a/test/testdata/codegen/004_var_decl.sa.json
+++ b/test/testdata/codegen/004_var_decl.sa.json
@@ -1,0 +1,16 @@
+{
+  "original": "/test/var_decl.pa",
+  "str-literals": [],
+  "statements": [
+    {
+      "stmt-type": "var-decl",
+      "vars": [
+        {
+          "var-name": "x",
+          "var-type": { "type-kind": "prim", "type-name": "int64" },
+          "init": { "expr-type": "lit-int", "value": "10" }
+        }
+      ]
+    }
+  ]
+}

--- a/test/testdata/codegen/004_var_decl.sa.json
+++ b/test/testdata/codegen/004_var_decl.sa.json
@@ -1,6 +1,8 @@
 {
   "original": "/test/var_decl.pa",
-  "str-literals": [],
+  "str-literals": [
+    { "label": ".str0", "value": "%lld\n" }
+  ],
   "statements": [
     {
       "stmt-type": "var-decl",
@@ -11,6 +13,18 @@
           "init": { "expr-type": "lit-int", "value": "10" }
         }
       ]
+    },
+    {
+      "stmt-type": "expr",
+      "body": {
+        "expr-type": "call",
+        "func-type": "c",
+        "name": "printf",
+        "args": [
+          { "expr-type": "lit-str", "value": "%lld\n" },
+          { "expr-type": "id",      "name":  "x" }
+        ]
+      }
     }
   ]
 }

--- a/test/testdata/codegen/005_addition.sa.json
+++ b/test/testdata/codegen/005_addition.sa.json
@@ -1,0 +1,39 @@
+{
+  "original": "/test/addition.pa",
+  "str-literals": [
+    { "label": ".str0", "value": "%lld\n" }
+  ],
+  "statements": [
+    {
+      "stmt-type": "var-decl",
+      "vars": [
+        {
+          "var-name": "x",
+          "var-type": { "type-kind": "prim", "type-name": "int64" },
+          "init": { "expr-type": "lit-int", "value": "10" }
+        },
+        {
+          "var-name": "y",
+          "var-type": { "type-kind": "prim", "type-name": "int64" },
+          "init": { "expr-type": "lit-int", "value": "20" }
+        }
+      ]
+    },
+    {
+      "stmt-type": "expr",
+      "body": {
+        "expr-type": "call",
+        "func-type": "c",
+        "name": "printf",
+        "args": [
+          { "expr-type": "lit-str", "value": "%lld\n" },
+          {
+            "expr-type": "add",
+            "left":  { "expr-type": "id", "name": "x" },
+            "right": { "expr-type": "id", "name": "y" }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add integer variable declaration with initialization (`int64 x = 10;`)
- Add binary addition operator (`x + y`)
- Display integer literals, variables, and expressions via printf
- Add script-mode to `palan`: when `-o` is not specified, the binary is executed and removed automatically

## Changes

### Language / Compiler
- `PlnParser`: emit `add` node for `+` operator
- `PlnSemanticAnalyzer`: propagate `add` node through SA pass
- `PlnNode`: add `AddExpr`; introduce `ExprKind`/`StmtKind` enums (replace `dynamic_cast` with `switch`/`static_cast`)
- `PlnVProg`: add `Add` VInstr
- `PlnDeserialize`: deserialize `add` node
- `PlnVCodeGen`: add `lowerExpr()` unifying all expression lowering; guard against silent wrong behavior when call expressions appear in argument position
- `PlnRegAlloc`: add `last_any_use` tracking for Add operands; rename `uses` → `call_uses`
- `PlnX86CodeGen`: emit `movq`/`addq` for `Add`; add `srcOperand()` helper

### Build Manager
- `palan`: run and remove `a.out` when `-o` is not specified (script-mode)

### Docs
- `ASTSpec.md`: document `var-decl` statement and `add` expression nodes
- `SpecAndDesign.md`: add v0.1.1 usage examples; document script-mode behavior

## Test plan
- [x] All test suites pass (`make`)
- [x] `bin/palan test/testdata/build-mgr/003_addition.pa` prints `30`

🤖 Generated with [Claude Code](https://claude.com/claude-code)