### PR TITLE
feat: v0.1.9 — subtraction, comparison operators, if/if-else, fibonacci

### DIFF
--- a/doc/ASTSpec.md
+++ b/doc/ASTSpec.md
@@ -1,7 +1,7 @@
 Palan Abstract Syntax Tree Json Specification
 ============================================
 
-ver. 0.1.7
+ver. 0.1.9
 
 \* - Required
 
@@ -112,7 +112,7 @@ Used in `func-def` bodies and standalone block statements.
 
 Statement model
 ---------------
-- stmt-type\* - Statement type: "import" "cinclude" "expr" "var-decl" "assign" "return" "tapple-decl" "block"
+- stmt-type\* - Statement type: "import" "cinclude" "expr" "var-decl" "assign" "return" "tapple-decl" "block" "if"
 - loc\* - Location Array (omitted for "not-impl")
   1. import - import module statement
     - path-type\* - Path type string: "src" "inc"
@@ -141,10 +141,14 @@ Statement model
   8. block - standalone block statement (`{ ... }`)
     - functions\* - Palan function definition list local to this block (may be empty array)
     - body\* - Statement model list (does not contain func-def entries)
+  9. if - if / if-else statement
+    - cond\* - Condition expression model
+    - then\* - Then-block object (block statement body)
+    - else - Else-block object or nested if statement (omitted when absent)
 
 Expression model
 ----------------
-- expr-type\* - Expression type string: "lit-str" "lit-int" "lit-uint" "id" "add" "call" "cast"
+- expr-type\* - Expression type string: "lit-str" "lit-int" "lit-uint" "id" "add" "sub" "cmp" "call" "cast"
 - loc\* - Location Array (omitted for "not-impl" and "assign-expr")
   1. lit-str - String literal
     - value\* - String value
@@ -157,10 +161,17 @@ Expression model
   5. add - Binary addition
     - left\*  - Left operand expression model
     - right\* - Right operand expression model
-  6. call - Function call expression
+  6. sub - Binary subtraction
+    - left\*  - Left operand expression model
+    - right\* - Right operand expression model
+  7. cmp - Comparison expression (result: 0 or 1 as int32)
+    - op\*    - Operator string: "<" "<=" ">" ">=" "==" "!="
+    - left\*  - Left operand expression model
+    - right\* - Right operand expression model
+  8. call - Function call expression
     - name\* - Function name string
     - args - Argument expression list
-  7. cast - Explicit type cast expression (`type-name(expr)` syntax)
+  9. cast - Explicit type cast expression (`type-name(expr)` syntax)
     - target-type\* - Target Variable type object
     - src\* - Source expression model
 

--- a/doc/PalanReference.md
+++ b/doc/PalanReference.md
@@ -1,6 +1,6 @@
 # Palan Language Reference
 
-**Version:** v0.1.8
+**Version:** v0.1.9
 
 Palan is a compiled systems programming language designed as a simpler, safer, and more enjoyable alternative to C. It targets developers who want low-level control and direct access to C libraries, without the sharp edges of C syntax. Palan code compiles to native x86-64 binaries via AT&T assembly, with no runtime overhead.
 
@@ -147,9 +147,13 @@ int32 a = 5, b = 10;   // type inheritance: b is also int32
 | String literal | `"..."` | `"hello\n"` |
 | Identifier | `name` | `x` |
 | Addition | `expr + expr` | `a + b` |
+| Subtraction | `expr - expr` | `a - b` |
+| Comparison | `expr < expr`, `<=`, `>`, `>=`, `==`, `!=` | `x < 10` |
 | Function call | `name(args)` | `add(3, 4)` |
 | Explicit cast | `type(expr)` | `int32(x)` |
 | Assignment expression | `expr -> var` | `x + 1 -> x` |
+
+Comparison operators produce `int32` (1 if true, 0 if false). Both operands are widened to the same type before comparison.
 
 The assignment expression `expr -> var` evaluates `expr`, stores it in `var`, and the result is the stored value.
 

--- a/doc/PalanReference.md
+++ b/doc/PalanReference.md
@@ -46,9 +46,10 @@ printf("%ld %ld\n", ab, bc);   // 3 5
 7. [Function Definitions](#7-function-definitions)
 8. [Receiving Multiple Return Values](#8-receiving-multiple-return-values)
 9. [C Library Integration](#9-c-library-integration)
-10. [Block Statements](#10-block-statements)
-11. [Modules (import / export)](#11-modules-import--export)
-12. [Program Structure](#12-program-structure)
+10. [If / If-Else Statements](#10-if--if-else-statements)
+11. [Block Statements](#11-block-statements)
+12. [Modules (import / export)](#12-modules-import--export)
+13. [Program Structure](#13-program-structure)
 
 ---
 
@@ -163,7 +164,9 @@ printf("%ld\n", x);        // expression statement (function call)
 return;                    // return from function (no value)
 return expr;               // return with single value
 (int64 a, b) = foo();      // tapple declaration (receive multiple return values)
-import "lib.pa";           // import Palan source file (see §11)
+import "lib.pa";           // import Palan source file (see §12)
+if expr { ... }            // conditional (see §10)
+if expr { ... } else { ... }  // conditional with else (see §10)
 ```
 
 ---
@@ -171,7 +174,7 @@ import "lib.pa";           // import Palan source file (see §11)
 ## 7. Function Definitions
 
 Functions are defined with the `func` keyword. Return values are declared after `->`.
-The optional `export` keyword makes the function callable from other Palan files that import this file (see §11).
+The optional `export` keyword makes the function callable from other Palan files that import this file (see §12).
 
 ### No Return Value
 
@@ -247,7 +250,44 @@ printf("%ld\n", x);      // call C function
 
 ---
 
-## 10. Block Statements
+## 10. If / If-Else Statements
+
+An `if` statement conditionally executes a block. The condition expression must be an integer type; zero is false, non-zero is true.
+
+```palan
+if x < 0 {
+    printf("negative\n");
+}
+```
+
+An optional `else` branch executes when the condition is false:
+
+```palan
+if x < 0 {
+    printf("negative\n");
+} else {
+    printf("non-negative\n");
+}
+```
+
+`else if` chains are supported:
+
+```palan
+if x < 0 {
+    printf("negative\n");
+} else if x == 0 {
+    printf("zero\n");
+} else {
+    printf("positive\n");
+}
+```
+
+- The condition can be any expression that produces an integer value (comparison, variable, call, etc.).
+- The `then` and `else` bodies are block statements and create their own scope.
+
+---
+
+## 11. Block Statements
 
 A block `{ ... }` creates a new scope. Variables and functions declared inside are not visible after the closing brace.
 
@@ -269,7 +309,7 @@ Palan function definitions inside a block are block-scoped and support forward r
 
 ---
 
-## 11. Modules (import / export)
+## 12. Modules (import / export)
 
 Palan supports multi-file compilation. Functions declared with `export` are visible to other files that `import` the declaring file.
 
@@ -300,7 +340,7 @@ printf("%d\n", add(3, 4));   // 7
 
 ---
 
-## 12. Program Structure
+## 13. Program Structure
 
 ```palan
 cinclude <stdio.h>;

--- a/doc/SASpec.md
+++ b/doc/SASpec.md
@@ -1,7 +1,7 @@
 Palan Semantic Analyzer JSON Specification
 ==========================================
 
-ver. 0.1.6
+ver. 0.1.9
 
 Output of palan-sa. Extends the AST JSON format (see ASTSpec.md) with resolved
 type information and pre-collected literal tables.
@@ -57,6 +57,12 @@ Same structure as AST statements (see ASTSpec.md) with the following differences
   - Palan function definitions inside a block are pre-registered (pass 1) to
     support forward references within the same block.
 
+- **if** - if / if-else statement
+  - stmt-type\*: "if"
+  - cond\*: SA-annotated condition expression (value-type present; integer expected)
+  - then\*: then-block (same structure as block stmt body in ASTSpec.md)
+  - else: else-block or nested if statement (omitted when absent)
+
 Additional statement kinds emitted by SA:
 
 - **assign** - assignment statement
@@ -85,6 +91,9 @@ Same structure as AST expressions (see ASTSpec.md) with the following additions:
   - id: same object as var-type
   - add: promoted type of left and right operands (see Promotion rules);
     the narrower operand is wrapped in a convert node if types differ
+  - sub: same promotion rules as add
+  - cmp: always `{"type-kind": "prim", "type-name": "int32"}` (result is 0 or 1);
+    left and right operands are promoted by the same rules as add
   - call: present when the function has a return type (ret-type in its definition)
 
 SA-only expression kinds (not present in AST JSON):

--- a/src/codegen/PlnDeserialize.cpp
+++ b/src/codegen/PlnDeserialize.cpp
@@ -57,6 +57,13 @@ static unique_ptr<Expr> deserializeExpr(const json& j)
         e->type  = j.contains("value-type") ? toVRegType(j["value-type"]) : VRegType::Int64;
         return e;
     }
+    if (expr_type == "sub") {
+        auto e = make_unique<SubExpr>();
+        e->left  = deserializeExpr(j["left"]);
+        e->right = deserializeExpr(j["right"]);
+        e->type  = j.contains("value-type") ? toVRegType(j["value-type"]) : VRegType::Int64;
+        return e;
+    }
     if (expr_type == "call") {
         string func_type = j.value("func-type", "");
         if (func_type == "c") {

--- a/src/codegen/PlnDeserialize.cpp
+++ b/src/codegen/PlnDeserialize.cpp
@@ -160,6 +160,23 @@ static unique_ptr<Stmt> deserializeStmt(const json& j)
         s->body = deserializeStatements(j["body"]);
         return s;
     }
+    if (stmt_type == "if") {
+        auto s = make_unique<IfStmt>();
+        s->cond = deserializeExpr(j["cond"]);
+        auto tb = make_unique<BlockStmt>();
+        tb->body = deserializeStatements(j["then"]["body"]);
+        s->thenStmt = move(tb);
+        if (j.contains("else")) {
+            if (j["else"]["stmt-type"] == "if") {
+                s->elseStmt = deserializeStmt(j["else"]);
+            } else {
+                auto eb = make_unique<BlockStmt>();
+                eb->body = deserializeStatements(j["else"]["body"]);
+                s->elseStmt = move(eb);
+            }
+        }
+        return s;
+    }
     if (stmt_type == "not-impl") {
         return nullptr;
     }

--- a/src/codegen/PlnDeserialize.cpp
+++ b/src/codegen/PlnDeserialize.cpp
@@ -64,6 +64,15 @@ static unique_ptr<Expr> deserializeExpr(const json& j)
         e->type  = j.contains("value-type") ? toVRegType(j["value-type"]) : VRegType::Int64;
         return e;
     }
+    if (expr_type == "cmp") {
+        auto e = make_unique<CmpExpr>();
+        e->op    = j["op"];
+        e->left  = deserializeExpr(j["left"]);
+        e->right = deserializeExpr(j["right"]);
+        e->operandType = j["left"].contains("value-type")
+                         ? toVRegType(j["left"]["value-type"]) : VRegType::Int64;
+        return e;
+    }
     if (expr_type == "call") {
         string func_type = j.value("func-type", "");
         if (func_type == "c") {

--- a/src/codegen/PlnNode.h
+++ b/src/codegen/PlnNode.h
@@ -22,6 +22,7 @@ enum class ExprKind {
     Id,
     Add,
     Sub,
+    Cmp,
     Convert,
     CCCall,
     PlnCall,
@@ -67,6 +68,14 @@ struct SubExpr : Expr {
     unique_ptr<Expr> left;
     unique_ptr<Expr> right;
     VRegType type = VRegType::Int64;
+};
+
+struct CmpExpr : Expr {
+    CmpExpr() : Expr(ExprKind::Cmp) {}
+    string           op;           // "<", "<=", ">", ">=", "==", "!="
+    unique_ptr<Expr> left;
+    unique_ptr<Expr> right;
+    VRegType operandType = VRegType::Int64;  // type of lhs/rhs operands
 };
 
 struct ConvertExpr : Expr {

--- a/src/codegen/PlnNode.h
+++ b/src/codegen/PlnNode.h
@@ -112,6 +112,7 @@ enum class StmtKind {
     Return,
     TappleDecl,
     Block,
+    If,
 };
 
 struct Stmt {
@@ -159,6 +160,13 @@ struct TappleDeclStmt : Stmt {
 struct BlockStmt : Stmt {
     BlockStmt() : Stmt(StmtKind::Block) {}
     vector<unique_ptr<Stmt>> body;
+};
+
+struct IfStmt : Stmt {
+    IfStmt() : Stmt(StmtKind::If) {}
+    unique_ptr<Expr> cond;
+    unique_ptr<Stmt> thenStmt;  // always BlockStmt
+    unique_ptr<Stmt> elseStmt;  // nullptr | BlockStmt | IfStmt (else-if chain)
 };
 
 // -------- Module --------

--- a/src/codegen/PlnNode.h
+++ b/src/codegen/PlnNode.h
@@ -21,6 +21,7 @@ enum class ExprKind {
     UintLit,
     Id,
     Add,
+    Sub,
     Convert,
     CCCall,
     PlnCall,
@@ -56,6 +57,13 @@ struct IdExpr : Expr {
 
 struct AddExpr : Expr {
     AddExpr() : Expr(ExprKind::Add) {}
+    unique_ptr<Expr> left;
+    unique_ptr<Expr> right;
+    VRegType type = VRegType::Int64;
+};
+
+struct SubExpr : Expr {
+    SubExpr() : Expr(ExprKind::Sub) {}
     unique_ptr<Expr> left;
     unique_ptr<Expr> right;
     VRegType type = VRegType::Int64;

--- a/src/codegen/PlnRegAlloc.cpp
+++ b/src/codegen/PlnRegAlloc.cpp
@@ -41,6 +41,16 @@ RegAllocResult allocateRegisters(const VFunc& func, const PhysRegs& phys)
             meta[a->dst].type    = a->type;
             meta[a->lhs].last_any_use = max(meta[a->lhs].last_any_use, i);
             meta[a->rhs].last_any_use = max(meta[a->rhs].last_any_use, i);
+        } else if (auto* s = get_if<Sub>(&instr)) {
+            meta[s->dst].def_idx = i;
+            meta[s->dst].type    = s->type;
+            meta[s->lhs].last_any_use = max(meta[s->lhs].last_any_use, i);
+            meta[s->rhs].last_any_use = max(meta[s->rhs].last_any_use, i);
+        } else if (auto* cm = get_if<Cmp>(&instr)) {
+            meta[cm->dst].def_idx = i;
+            meta[cm->dst].type    = VRegType::Int32;
+            meta[cm->lhs].last_any_use = max(meta[cm->lhs].last_any_use, i);
+            meta[cm->rhs].last_any_use = max(meta[cm->rhs].last_any_use, i);
         } else if (auto* c = get_if<CallC>(&instr)) {
             call_indices.push_back(i);
             for (int j = 0; j < (int)c->args.size(); j++) {
@@ -65,6 +75,8 @@ RegAllocResult allocateRegisters(const VFunc& func, const PhysRegs& phys)
                 meta[r->rets[k]].isRetValue = true;
                 meta[r->rets[k]].retIdx     = k;
             }
+        } else if (auto* cj = get_if<CondJmp>(&instr)) {
+            meta[cj->cond].last_any_use = max(meta[cj->cond].last_any_use, i);
         }
     }
 

--- a/src/codegen/PlnVCodeGen.cpp
+++ b/src/codegen/PlnVCodeGen.cpp
@@ -250,6 +250,28 @@ void PlnVCodeGen::lowerBlockStmt(const BlockStmt& stmt, VFunc& func)
     func.instrs.push_back(BlockLeave{move(expired)});
 }
 
+void PlnVCodeGen::lowerIfStmt(const IfStmt& stmt, VFunc& func)
+{
+    int    idx      = labelCounter_++;
+    string endLabel = ".Lif" + to_string(idx) + "_end";
+
+    VReg cond = lowerExpr(*stmt.cond, func);
+
+    if (stmt.elseStmt) {
+        string elseLabel = ".Lif" + to_string(idx) + "_else";
+        func.instrs.push_back(CondJmp{elseLabel, cond, true});
+        lowerStmt(*stmt.thenStmt, func);
+        func.instrs.push_back(Jmp{endLabel});
+        func.instrs.push_back(Label{elseLabel});
+        lowerStmt(*stmt.elseStmt, func);
+    } else {
+        func.instrs.push_back(CondJmp{endLabel, cond, true});
+        lowerStmt(*stmt.thenStmt, func);
+    }
+
+    func.instrs.push_back(Label{endLabel});
+}
+
 void PlnVCodeGen::lowerStmt(const Stmt& stmt, VFunc& func)
 {
     switch (stmt.kind) {
@@ -270,6 +292,9 @@ void PlnVCodeGen::lowerStmt(const Stmt& stmt, VFunc& func)
             return;
         case StmtKind::Block:
             lowerBlockStmt(static_cast<const BlockStmt&>(stmt), func);
+            return;
+        case StmtKind::If:
+            lowerIfStmt(static_cast<const IfStmt&>(stmt), func);
             return;
     }
     BOOST_ASSERT(false);

--- a/src/codegen/PlnVCodeGen.cpp
+++ b/src/codegen/PlnVCodeGen.cpp
@@ -79,6 +79,14 @@ VReg PlnVCodeGen::lowerExpr(const Expr& expr, VFunc& func)
             func.instrs.push_back(Add{dst, l, r, e.type});
             return dst;
         }
+        case ExprKind::Sub: {
+            auto& e  = static_cast<const SubExpr&>(expr);
+            VReg l   = lowerExpr(*e.left, func);
+            VReg r   = lowerExpr(*e.right, func);
+            VReg dst = allocVReg();
+            func.instrs.push_back(Sub{dst, l, r, e.type});
+            return dst;
+        }
         case ExprKind::CCCall: {
             auto& e = static_cast<const CCCallExpr&>(expr);
             BOOST_ASSERT(e.hasRet);

--- a/src/codegen/PlnVCodeGen.cpp
+++ b/src/codegen/PlnVCodeGen.cpp
@@ -87,6 +87,14 @@ VReg PlnVCodeGen::lowerExpr(const Expr& expr, VFunc& func)
             func.instrs.push_back(Sub{dst, l, r, e.type});
             return dst;
         }
+        case ExprKind::Cmp: {
+            auto& e  = static_cast<const CmpExpr&>(expr);
+            VReg l   = lowerExpr(*e.left, func);
+            VReg r   = lowerExpr(*e.right, func);
+            VReg dst = allocVReg();
+            func.instrs.push_back(Cmp{dst, e.op, l, r, e.operandType});
+            return dst;
+        }
         case ExprKind::CCCall: {
             auto& e = static_cast<const CCCallExpr&>(expr);
             BOOST_ASSERT(e.hasRet);

--- a/src/codegen/PlnVCodeGen.h
+++ b/src/codegen/PlnVCodeGen.h
@@ -16,6 +16,7 @@ using std::vector;
 
 class PlnVCodeGen {
     int nextVReg = 0;
+    int labelCounter_ = 0;  // unique label index for control-flow labels
 
     // Variable symbol table: scoped stack of name -> VReg mappings.
     // enterVarScope/leaveVarScope push/pop; findVar searches from innermost.
@@ -40,6 +41,7 @@ class PlnVCodeGen {
     void lowerPlnCallExpr(const PlnCallExpr& expr, VFunc& func);
     void lowerTappleDeclStmt(const TappleDeclStmt& stmt, VFunc& func);
     void lowerBlockStmt(const BlockStmt& stmt, VFunc& func);
+    void lowerIfStmt(const IfStmt& stmt, VFunc& func);
 
 public:
     VProg generate(const Module& module, bool noEntry = false);

--- a/src/codegen/PlnVProg.h
+++ b/src/codegen/PlnVProg.h
@@ -40,10 +40,14 @@ struct RetPln   { vector<VReg> rets; vector<VRegType> types; };
 struct ExitCode { int code; };
 struct BlockEnter {};
 struct BlockLeave { vector<VReg> expiredVars; };
+struct Label      { string name; };                              // name:
+struct Jmp        { string label; };                             // jmp label
+struct CondJmp    { string label; VReg cond; bool jumpIfZero; }; // testl+je/jne
 
 using VInstr = std::variant<LeaLabel, MovImm, InitVar, Add, Sub, Cmp, Convert,
                              CallC, CallPln, RetPln, ExitCode,
-                             BlockEnter, BlockLeave>;
+                             BlockEnter, BlockLeave,
+                             Label, Jmp, CondJmp>;
 
 // -------- Program structure --------
 

--- a/src/codegen/PlnVProg.h
+++ b/src/codegen/PlnVProg.h
@@ -31,6 +31,7 @@ struct LeaLabel { VReg dst; VRegType type; string label; };       // dst = addre
 struct MovImm   { VReg dst; VRegType type; long long value; };    // dst = immediate integer
 struct InitVar  { VReg dst; VRegType type; long long imm; };      // variable init: dst_vreg = imm
 struct Add      { VReg dst; VReg lhs; VReg rhs; VRegType type; }; // dst = lhs + rhs
+struct Sub      { VReg dst; VReg lhs; VReg rhs; VRegType type; }; // dst = lhs - rhs
 struct Convert  { VReg dst; VReg src; VRegType from; VRegType to; }; // dst = (to)src
 struct CallC    { string name; vector<VReg> args; VReg dst = -1; VRegType retType = VRegType::Int64; };
 struct CallPln  { string name; vector<VReg> args; vector<VReg> dsts; vector<VRegType> retTypes; };
@@ -39,7 +40,7 @@ struct ExitCode { int code; };
 struct BlockEnter {};
 struct BlockLeave { vector<VReg> expiredVars; };
 
-using VInstr = std::variant<LeaLabel, MovImm, InitVar, Add, Convert,
+using VInstr = std::variant<LeaLabel, MovImm, InitVar, Add, Sub, Convert,
                              CallC, CallPln, RetPln, ExitCode,
                              BlockEnter, BlockLeave>;
 

--- a/src/codegen/PlnVProg.h
+++ b/src/codegen/PlnVProg.h
@@ -32,6 +32,7 @@ struct MovImm   { VReg dst; VRegType type; long long value; };    // dst = immed
 struct InitVar  { VReg dst; VRegType type; long long imm; };      // variable init: dst_vreg = imm
 struct Add      { VReg dst; VReg lhs; VReg rhs; VRegType type; }; // dst = lhs + rhs
 struct Sub      { VReg dst; VReg lhs; VReg rhs; VRegType type; }; // dst = lhs - rhs
+struct Cmp      { VReg dst; string op; VReg lhs; VReg rhs; VRegType type; }; // dst (int32) = (lhs op rhs) ? 1 : 0
 struct Convert  { VReg dst; VReg src; VRegType from; VRegType to; }; // dst = (to)src
 struct CallC    { string name; vector<VReg> args; VReg dst = -1; VRegType retType = VRegType::Int64; };
 struct CallPln  { string name; vector<VReg> args; vector<VReg> dsts; vector<VRegType> retTypes; };
@@ -40,7 +41,7 @@ struct ExitCode { int code; };
 struct BlockEnter {};
 struct BlockLeave { vector<VReg> expiredVars; };
 
-using VInstr = std::variant<LeaLabel, MovImm, InitVar, Add, Sub, Convert,
+using VInstr = std::variant<LeaLabel, MovImm, InitVar, Add, Sub, Cmp, Convert,
                              CallC, CallPln, RetPln, ExitCode,
                              BlockEnter, BlockLeave>;
 

--- a/src/codegen/PlnX86CodeGen.cpp
+++ b/src/codegen/PlnX86CodeGen.cpp
@@ -166,7 +166,11 @@ void PlnX86CodeGen::emit(const VProg& prog)
                 emitLeaLabel(sizedRegName(loc.base, loc.type), i->label);
             } else if (auto* i = std::get_if<MovImm>(&instr)) {
                 const PhysLoc& loc = rm.at(i->dst);
-                emitMovImm(sizedRegName(loc.base, i->type), i->type, i->value);
+                if (loc.isStack()) {
+                    out << "\t" << movInstrForType(i->type) << " $" << i->value << ", " << srcOperand(loc) << "\n";
+                } else {
+                    emitMovImm(sizedRegName(loc.base, i->type), i->type, i->value);
+                }
             } else if (auto* i = std::get_if<InitVar>(&instr)) {
                 const PhysLoc& loc = rm.at(i->dst);
                 if (loc.isStack()) {
@@ -183,12 +187,12 @@ void PlnX86CodeGen::emit(const VProg& prog)
                     out << "\t" << movInstrForType(a->type) << " " << srcOperand(lhs_loc) << ", " << dst_reg << "\n";
                     out << "\t" << addInstrForType(a->type) << " " << srcOperand(rm.at(a->rhs)) << ", " << dst_reg << "\n";
                 } else {
-                    // Spilled dst: use memory destination (x86 allows reg/imm src with mem dst).
-                    // lhs must be in a register so mov-to-mem is valid.
-                    BOOST_ASSERT(!lhs_loc.isStack());
+                    // Spilled dst: route through scratch %rax to avoid mem-mem.
+                    string scratch = sizedRegName("%rax", a->type);
                     string dst_mem = srcOperand(dst_loc);
-                    out << "\t" << movInstrForType(a->type) << " " << srcOperand(lhs_loc) << ", " << dst_mem << "\n";
-                    out << "\t" << addInstrForType(a->type) << " " << srcOperand(rm.at(a->rhs)) << ", " << dst_mem << "\n";
+                    out << "\t" << movInstrForType(a->type) << " " << srcOperand(lhs_loc) << ", " << scratch << "\n";
+                    out << "\t" << addInstrForType(a->type) << " " << srcOperand(rm.at(a->rhs)) << ", " << scratch << "\n";
+                    out << "\t" << movInstrForType(a->type) << " " << scratch << ", " << dst_mem << "\n";
                 }
             } else if (auto* s = std::get_if<Sub>(&instr)) {
                 if (!rm.count(s->dst)) continue;  // dead: result never used
@@ -199,10 +203,12 @@ void PlnX86CodeGen::emit(const VProg& prog)
                     out << "\t" << movInstrForType(s->type) << " " << srcOperand(lhs_loc) << ", " << dst_reg << "\n";
                     out << "\t" << subInstrForType(s->type) << " " << srcOperand(rm.at(s->rhs)) << ", " << dst_reg << "\n";
                 } else {
-                    BOOST_ASSERT(!lhs_loc.isStack());
+                    // Spilled dst: route through scratch %rax to avoid mem-mem.
+                    string scratch = sizedRegName("%rax", s->type);
                     string dst_mem = srcOperand(dst_loc);
-                    out << "\t" << movInstrForType(s->type) << " " << srcOperand(lhs_loc) << ", " << dst_mem << "\n";
-                    out << "\t" << subInstrForType(s->type) << " " << srcOperand(rm.at(s->rhs)) << ", " << dst_mem << "\n";
+                    out << "\t" << movInstrForType(s->type) << " " << srcOperand(lhs_loc) << ", " << scratch << "\n";
+                    out << "\t" << subInstrForType(s->type) << " " << srcOperand(rm.at(s->rhs)) << ", " << scratch << "\n";
+                    out << "\t" << movInstrForType(s->type) << " " << scratch << ", " << dst_mem << "\n";
                 }
             } else if (auto* cm = std::get_if<Cmp>(&instr)) {
                 if (!rm.count(cm->dst)) continue;  // dead
@@ -318,6 +324,21 @@ void PlnX86CodeGen::emit(const VProg& prog)
                 // no-op
             } else if (std::get_if<BlockLeave>(&instr)) {
                 // no-op
+            } else if (auto* l = std::get_if<Label>(&instr)) {
+                out << l->name << ":\n";
+            } else if (auto* j = std::get_if<Jmp>(&instr)) {
+                out << "\tjmp " << j->label << "\n";
+            } else if (auto* cj = std::get_if<CondJmp>(&instr)) {
+                const PhysLoc& loc = rm.at(cj->cond);
+                string cond_reg;
+                if (loc.isStack()) {
+                    out << "\tmovl " << srcOperand(loc) << ", %eax\n";
+                    cond_reg = "%eax";
+                } else {
+                    cond_reg = sizedRegName(loc.base, VRegType::Int32);
+                }
+                out << "\ttestl " << cond_reg << ", " << cond_reg << "\n";
+                out << (cj->jumpIfZero ? "\tje " : "\tjne ") << cj->label << "\n";
             }
         }
     }

--- a/src/codegen/PlnX86CodeGen.cpp
+++ b/src/codegen/PlnX86CodeGen.cpp
@@ -23,6 +23,15 @@ static const char* addInstrForType(VRegType type) {
     }
 }
 
+static const char* subInstrForType(VRegType type) {
+    switch (type) {
+        case VRegType::Int8:  return "subb";
+        case VRegType::Int16: return "subw";
+        case VRegType::Int32: return "subl";
+        default:              return "subq";
+    }
+}
+
 // Derive the sized register name from the 64-bit base name and VRegType.
 // Classic registers (%rax/%rbx/...): drop 'r' prefix for 32-bit, use bare name for 16/8-bit.
 // Extended registers (%r8-%r15): append 'd'/'w'/'b' suffix.
@@ -161,6 +170,20 @@ void PlnX86CodeGen::emit(const VProg& prog)
                     string dst_mem = srcOperand(dst_loc);
                     out << "\t" << movInstrForType(a->type) << " " << srcOperand(lhs_loc) << ", " << dst_mem << "\n";
                     out << "\t" << addInstrForType(a->type) << " " << srcOperand(rm.at(a->rhs)) << ", " << dst_mem << "\n";
+                }
+            } else if (auto* s = std::get_if<Sub>(&instr)) {
+                if (!rm.count(s->dst)) continue;  // dead: result never used
+                const PhysLoc& dst_loc = rm.at(s->dst);
+                const PhysLoc& lhs_loc = rm.at(s->lhs);
+                if (!dst_loc.isStack()) {
+                    string dst_reg = sizedRegName(dst_loc.base, s->type);
+                    out << "\t" << movInstrForType(s->type) << " " << srcOperand(lhs_loc) << ", " << dst_reg << "\n";
+                    out << "\t" << subInstrForType(s->type) << " " << srcOperand(rm.at(s->rhs)) << ", " << dst_reg << "\n";
+                } else {
+                    BOOST_ASSERT(!lhs_loc.isStack());
+                    string dst_mem = srcOperand(dst_loc);
+                    out << "\t" << movInstrForType(s->type) << " " << srcOperand(lhs_loc) << ", " << dst_mem << "\n";
+                    out << "\t" << subInstrForType(s->type) << " " << srcOperand(rm.at(s->rhs)) << ", " << dst_mem << "\n";
                 }
             } else if (auto* c = std::get_if<Convert>(&instr)) {
                 if (!rm.count(c->dst)) continue;  // dead

--- a/src/codegen/PlnX86CodeGen.cpp
+++ b/src/codegen/PlnX86CodeGen.cpp
@@ -32,6 +32,25 @@ static const char* subInstrForType(VRegType type) {
     }
 }
 
+static const char* cmpInstrForType(VRegType type) {
+    switch (type) {
+        case VRegType::Int8:  return "cmpb";
+        case VRegType::Int16: return "cmpw";
+        case VRegType::Int32: return "cmpl";
+        default:              return "cmpq";
+    }
+}
+
+static const char* setCCForOp(const string& op) {
+    if (op == "<")  return "setl";
+    if (op == "<=") return "setle";
+    if (op == ">")  return "setg";
+    if (op == ">=") return "setge";
+    if (op == "==") return "sete";
+    if (op == "!=") return "setne";
+    BOOST_ASSERT(false); return "";
+}
+
 // Derive the sized register name from the 64-bit base name and VRegType.
 // Classic registers (%rax/%rbx/...): drop 'r' prefix for 32-bit, use bare name for 16/8-bit.
 // Extended registers (%r8-%r15): append 'd'/'w'/'b' suffix.
@@ -184,6 +203,33 @@ void PlnX86CodeGen::emit(const VProg& prog)
                     string dst_mem = srcOperand(dst_loc);
                     out << "\t" << movInstrForType(s->type) << " " << srcOperand(lhs_loc) << ", " << dst_mem << "\n";
                     out << "\t" << subInstrForType(s->type) << " " << srcOperand(rm.at(s->rhs)) << ", " << dst_mem << "\n";
+                }
+            } else if (auto* cm = std::get_if<Cmp>(&instr)) {
+                if (!rm.count(cm->dst)) continue;  // dead
+                const PhysLoc& dst_loc  = rm.at(cm->dst);
+                const PhysLoc& lhs_loc  = rm.at(cm->lhs);
+                // cmpX %rhs, lhs  →  flags = lhs - rhs
+                // x86 disallows two memory operands: load lhs into scratch if spilled
+                string lhs_operand;
+                if (lhs_loc.isStack()) {
+                    string scratch = sizedRegName("%rax", cm->type);
+                    out << "\t" << movInstrForType(cm->type) << " " << srcOperand(lhs_loc) << ", " << scratch << "\n";
+                    lhs_operand = scratch;
+                } else {
+                    lhs_operand = srcOperand(lhs_loc);
+                }
+                out << "\t" << cmpInstrForType(cm->type)
+                    << " " << srcOperand(rm.at(cm->rhs))
+                    << ", " << lhs_operand << "\n";
+                if (!dst_loc.isStack()) {
+                    string dst_byte = sizedRegName(dst_loc.base, VRegType::Int8);
+                    string dst_32   = sizedRegName(dst_loc.base, VRegType::Int32);
+                    out << "\t" << setCCForOp(cm->op) << " " << dst_byte << "\n";
+                    out << "\tmovzbl " << dst_byte << ", " << dst_32 << "\n";
+                } else {
+                    out << "\t" << setCCForOp(cm->op) << " %al\n";
+                    out << "\tmovzbl %al, %eax\n";
+                    out << "\tmovl %eax, " << srcOperand(dst_loc) << "\n";
                 }
             } else if (auto* c = std::get_if<Convert>(&instr)) {
                 if (!rm.count(c->dst)) continue;  // dead

--- a/src/common/PlnDefs.h
+++ b/src/common/PlnDefs.h
@@ -5,4 +5,4 @@
 
 #pragma once
 
-#define PALAN_VERSION "0.1.8"
+#define PALAN_VERSION "0.1.9"

--- a/src/gen-ast/PlnLexer.ll
+++ b/src/gen-ast/PlnLexer.ll
@@ -50,7 +50,9 @@ enum {
 	ARROW =	PlnParser::token::ARROW,
 	DBL_ARROW =	PlnParser::token::DBL_ARROW,
 	AT_EXCL =	PlnParser::token::AT_EXCL,
-	DBL_PLUS =	PlnParser::token::DBL_PLUS
+	DBL_PLUS =	PlnParser::token::DBL_PLUS,
+	OPE_EQ =	PlnParser::token::OPE_EQ,
+	OPE_NE =	PlnParser::token::OPE_NE
 };
 
 static string& unescape(string& str);
@@ -142,6 +144,8 @@ COMMENT1	\/\/[^\n]*\n
 <*>"->>"	{ return DBL_ARROW; }
 <*>"@!"	{ return AT_EXCL; }
 <*>"++"	{ return DBL_PLUS; }
+<*>"=="	{ return OPE_EQ; }
+<*>"!="	{ return OPE_NE; }
 <*>[ \t]+	{ loc.step(); }
 <*>\r\n|\r|\n	{ loc.lines(); loc.step(); }
 <*><<EOF>>	{ return 0; }

--- a/src/gen-ast/PlnParser.yy
+++ b/src/gen-ast/PlnParser.yy
@@ -526,7 +526,7 @@ expression: term
 	| expression '+' expression
 	{ $$ = {{"expr-type", "add"}, {"left", $1}, {"right", $3}}; LOC($$, @$); }
 	| expression '-' expression
-	{ $$ = {{"expr-type", "not-impl"}}; }
+	{ $$ = {{"expr-type", "sub"}, {"left", $1}, {"right", $3}}; LOC($$, @$); }
 	| expression '*' expression
 	{ $$ = {{"expr-type", "not-impl"}}; }
 	| expression '/' expression

--- a/src/gen-ast/PlnParser.yy
+++ b/src/gen-ast/PlnParser.yy
@@ -151,6 +151,7 @@ class PlnLexer;
 %type <json>	statement_or_funcdef
 %type <bool>	move_owner_r do_export
 %type <json>	tapple_decl tapple_decl_inner
+%type <json>	if_stmt else_stmt
 
 %left ARROW DBL_ARROW
 %left OPE_EQ OPE_NE
@@ -291,8 +292,7 @@ statement: import ';'
 	}
 	| if_stmt
 	{
-		json temp = {{"stmt-type", "not-impl"}};
-		$$ = move(temp);
+		$$ = move($1);
 	}
 	| term DBL_PLUS ';'
 	{
@@ -702,11 +702,20 @@ while_loop: KW_WHILE expression block
 	;
 
 if_stmt: KW_IF expression block else_stmt
+	{
+		json then_block = {{"stmt-type", "block"}, {"body", move($3)}};
+		$$ = {{"stmt-type", "if"}, {"cond", $2}, {"then", move(then_block)}};
+		if (!$4.is_null()) $$["else"] = move($4);
+		LOC($$, @$);
+	}
 	;
 
 else_stmt: /* empty */
+	{ $$ = json{}; }
 	| KW_ELSE block
+	{ $$ = {{"stmt-type", "block"}, {"body", move($2)}}; }
 	| KW_ELSE if_stmt
+	{ $$ = move($2); }
 	;
 
 expressions: expression

--- a/src/gen-ast/PlnParser.yy
+++ b/src/gen-ast/PlnParser.yy
@@ -130,6 +130,8 @@ class PlnLexer;
 %token DBL_ARROW	"->>"
 %token AT_EXCL	"@!"
 %token DBL_PLUS	"++"
+%token OPE_EQ	"=="
+%token OPE_NE	"!="
 
 %type <vector<json>>	statements
 %type <json>	statement
@@ -151,6 +153,7 @@ class PlnLexer;
 %type <json>	tapple_decl tapple_decl_inner
 
 %left ARROW DBL_ARROW
+%left OPE_EQ OPE_NE
 %left '<' '>' OPE_LE OPE_GE
 %left '+' '-'
 %left '*' '/' '%' '&' '|'
@@ -538,13 +541,17 @@ expression: term
 	| expression '|' expression
 	{ $$ = {{"expr-type", "not-impl"}}; }
 	| expression OPE_LE expression
-	{ $$ = {{"expr-type", "not-impl"}}; }
+	{ $$ = {{"expr-type", "cmp"}, {"op", "<="}, {"left", $1}, {"right", $3}}; LOC($$, @$); }
 	| expression OPE_GE expression
-	{ $$ = {{"expr-type", "not-impl"}}; }
+	{ $$ = {{"expr-type", "cmp"}, {"op", ">="}, {"left", $1}, {"right", $3}}; LOC($$, @$); }
 	| expression '<' expression
-	{ $$ = {{"expr-type", "not-impl"}}; }
+	{ $$ = {{"expr-type", "cmp"}, {"op", "<"},  {"left", $1}, {"right", $3}}; LOC($$, @$); }
 	| expression '>' expression
-	{ $$ = {{"expr-type", "not-impl"}}; }
+	{ $$ = {{"expr-type", "cmp"}, {"op", ">"},  {"left", $1}, {"right", $3}}; LOC($$, @$); }
+	| expression OPE_EQ expression
+	{ $$ = {{"expr-type", "cmp"}, {"op", "=="}, {"left", $1}, {"right", $3}}; LOC($$, @$); }
+	| expression OPE_NE expression
+	{ $$ = {{"expr-type", "cmp"}, {"op", "!="}, {"left", $1}, {"right", $3}}; LOC($$, @$); }
 	| expression ARROW expression
 	{
 		if ($3.value("expr-type", "") == "id") {

--- a/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
+++ b/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
@@ -215,6 +215,25 @@ json PlnSemanticAnalyzer::sa_expression(const json &expr, const PlnType* expecte
 		sa_expr["right"]      = right;
 		sa_expr["value-type"] = registry_.toJson(promoted);
 
+	} else if (expr_type == "sub") {
+		json left  = sa_expression(expr["left"]);
+		json right = sa_expression(expr["right"]);
+		const PlnType* leftType  = registry_.fromJson(left["value-type"]);
+		const PlnType* rightType = registry_.fromJson(right["value-type"]);
+		const PlnType* promoted;
+		if (typeCompat(leftType, rightType, registry_) == TypeCompat::ImplicitWiden) {
+			promoted = rightType;
+			left = wrapConvert(left, registry_.toJson(promoted));
+		} else if (typeCompat(rightType, leftType, registry_) == TypeCompat::ImplicitWiden) {
+			promoted = leftType;
+			right = wrapConvert(right, registry_.toJson(promoted));
+		} else {
+			promoted = leftType;
+		}
+		sa_expr["left"]       = left;
+		sa_expr["right"]      = right;
+		sa_expr["value-type"] = registry_.toJson(promoted);
+
 	} else if (expr_type == "cast") {
 		const PlnType* target  = registry_.fromJson(expr["target-type"]);
 		json src               = sa_expression(expr["src"]);

--- a/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
+++ b/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
@@ -153,6 +153,7 @@ json PlnSemanticAnalyzer::sa_statements(const json& stmts)
 		else if (t == "assign")   result.push_back(sa_assign_stmt(stmt));
 		else if (t == "return")      result.push_back(sa_return_stmt(stmt));
 		else if (t == "tapple-decl") result.push_back(sa_tapple_decl(stmt));
+		else if (t == "if")       result.push_back(sa_if_stmt(stmt));
 		else if (t == "not-impl")    result.push_back(stmt);
 		else if (t == "func-def") {
 			cerr << locPrefix(stmt) << PlnSaMessage::getMessage(E_InternalError, "1") << endl;
@@ -391,6 +392,24 @@ json PlnSemanticAnalyzer::sa_block(const json& stmt)
 
 	leaveScope();
 	return {{"stmt-type", "block"}, {"body", move(body)}};
+}
+
+json PlnSemanticAnalyzer::sa_if_stmt(const json& stmt)
+{
+	json result;
+	result["stmt-type"] = "if";
+	result["cond"] = sa_expression(stmt["cond"]);
+	result["then"] = sa_block(stmt["then"]);
+	if (stmt.contains("else")) {
+		const json& els = stmt["else"];
+		if (els["stmt-type"] == "if")
+			result["else"] = sa_if_stmt(els);
+		else
+			result["else"] = sa_block(els);
+	}
+	if (stmt.contains("loc"))
+		result["loc"] = stmt["loc"];
+	return result;
 }
 
 void PlnSemanticAnalyzer::sa_function(const json& funcDef)

--- a/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
+++ b/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
@@ -234,6 +234,21 @@ json PlnSemanticAnalyzer::sa_expression(const json &expr, const PlnType* expecte
 		sa_expr["right"]      = right;
 		sa_expr["value-type"] = registry_.toJson(promoted);
 
+	} else if (expr_type == "cmp") {
+		json left  = sa_expression(expr["left"]);
+		json right = sa_expression(expr["right"]);
+		const PlnType* leftType  = registry_.fromJson(left["value-type"]);
+		const PlnType* rightType = registry_.fromJson(right["value-type"]);
+		if (typeCompat(leftType, rightType, registry_) == TypeCompat::ImplicitWiden) {
+			left = wrapConvert(left, registry_.toJson(rightType));
+		} else if (typeCompat(rightType, leftType, registry_) == TypeCompat::ImplicitWiden) {
+			right = wrapConvert(right, registry_.toJson(leftType));
+		}
+		sa_expr["op"]         = expr["op"];
+		sa_expr["left"]       = left;
+		sa_expr["right"]      = right;
+		sa_expr["value-type"] = {{"type-kind", "prim"}, {"type-name", "int32"}};
+
 	} else if (expr_type == "cast") {
 		const PlnType* target  = registry_.fromJson(expr["target-type"]);
 		json src               = sa_expression(expr["src"]);

--- a/src/semantic-anlyzr/PlnSemanticAnalyzer.h
+++ b/src/semantic-anlyzr/PlnSemanticAnalyzer.h
@@ -54,6 +54,7 @@ class PlnSemanticAnalyzer {
 	json sa_return_stmt(const json& stmt);
 	json sa_tapple_decl(const json& stmt);
 	json sa_block(const json& stmt);
+	json sa_if_stmt(const json& stmt);
 
 public:
 	PlnSemanticAnalyzer(string base_path, string ast_filename, string c2ast_path);

--- a/test/build-mgr-tester/basicTests.cpp
+++ b/test/build-mgr-tester/basicTests.cpp
@@ -43,6 +43,12 @@ TEST(build_mgr, import_mutual) {
 	ASSERT_EQ(output, "10\n13\n");
 }
 
+TEST(build_mgr, fibonacci) {
+	cleanTestEnv();
+	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/006_fibonacci.pa");
+	ASSERT_EQ(output, "55\n");
+}
+
 TEST(build_mgr, clean) {
 	cleanTestEnv();
 

--- a/test/build-mgr-tester/basicTests.cpp
+++ b/test/build-mgr-tester/basicTests.cpp
@@ -14,7 +14,7 @@ TEST(build_mgr, helloworld) {
 TEST(build_mgr, basic_expr) {
 	cleanTestEnv();
 	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/101_basic_expr.pa");
-	ASSERT_EQ(output, "10\n30\n10\n100\n42\n100 100 50 50\n");
+	ASSERT_EQ(output, "10\n30\n10\n100\n42\n100 100 50 50\n7\n1 1 0\n0 0 1\n");
 }
 
 TEST(build_mgr, func_def) {

--- a/test/codegen-tester/basicTests.cpp
+++ b/test/codegen-tester/basicTests.cpp
@@ -287,10 +287,9 @@ TEST(codegen, named_ret_double_assign) {
     ASSERT_NE(asm_text.find("movq -8(%rbp), %rbx"),   string::npos);
     ASSERT_NE(asm_text.find("movq %r15, -40(%rbp)"),  string::npos);
     ASSERT_NE(asm_text.find("movq -40(%rbp), %r15"),  string::npos);
-    // Add with memory destination: the spilled Add result is stored directly to stack
-    // Note: isVar slots are now allocated in Pass B (after Pass A non-var spills),
-    // so the spill offset is -48 instead of -56.
-    ASSERT_NE(asm_text.find("addq %r15, -48(%rbp)"),  string::npos);
+    // Add with spilled dst: routed through scratch %rax to avoid mem-mem.
+    ASSERT_NE(asm_text.find("addq %r15, %rax"),       string::npos);
+    ASSERT_NE(asm_text.find("movq %rax, -48(%rbp)"),  string::npos);
     ASSERT_NE(asm_text.find("ret"),          string::npos);
 }
 
@@ -343,4 +342,41 @@ TEST(codegen, block_stmt) {
     // no extra block-related assembly instructions leaked
     ASSERT_EQ(asm_text.find("BlockEnter"),  string::npos);
     ASSERT_EQ(asm_text.find("BlockLeave"),  string::npos);
+}
+
+TEST(codegen, if_stmt) {
+    cleanTestEnv();
+    string sa   = "../test/testdata/codegen/019_if_stmt.sa.json";
+    string asmf = "out/019_if_stmt.s";
+
+    string err = run_codegen(sa, asmf);
+    ASSERT_EQ(err, "");
+
+    string asm_text = readFile(asmf);
+    // condition: testl + je to end label
+    ASSERT_NE(asm_text.find("testl"),       string::npos);
+    ASSERT_NE(asm_text.find("je "),         string::npos);
+    ASSERT_NE(asm_text.find(".Lif0_end:"),  string::npos);
+    ASSERT_NE(asm_text.find("call printf"), string::npos);
+    // no else: no jmp instruction
+    ASSERT_EQ(asm_text.find("\tjmp "),      string::npos);
+}
+
+TEST(codegen, if_else_stmt) {
+    cleanTestEnv();
+    string sa   = "../test/testdata/codegen/020_if_else_stmt.sa.json";
+    string asmf = "out/020_if_else_stmt.s";
+
+    string err = run_codegen(sa, asmf);
+    ASSERT_EQ(err, "");
+
+    string asm_text = readFile(asmf);
+    // conditional jump to else label
+    ASSERT_NE(asm_text.find("testl"),            string::npos);
+    ASSERT_NE(asm_text.find("je "),              string::npos);
+    ASSERT_NE(asm_text.find(".Lif0_else:"),      string::npos);
+    ASSERT_NE(asm_text.find(".Lif0_end:"),       string::npos);
+    // unconditional jmp to end after then-block
+    ASSERT_NE(asm_text.find("\tjmp .Lif0_end"),  string::npos);
+    ASSERT_NE(asm_text.find("call printf"),      string::npos);
 }

--- a/test/codegen-tester/basicTests.cpp
+++ b/test/codegen-tester/basicTests.cpp
@@ -78,8 +78,9 @@ TEST(codegen, addition) {
     ASSERT_EQ(err, "");
 
     string asm_text = readFile(asmf);
-    ASSERT_NE(asm_text.find("movq"),       string::npos);
-    ASSERT_NE(asm_text.find("addq"),       string::npos);
+    ASSERT_NE(asm_text.find("movq"),        string::npos);
+    ASSERT_NE(asm_text.find("addq"),        string::npos);
+    ASSERT_NE(asm_text.find("subq"),        string::npos);
     ASSERT_NE(asm_text.find("call printf"), string::npos);
 }
 

--- a/test/codegen-tester/basicTests.cpp
+++ b/test/codegen-tester/basicTests.cpp
@@ -84,6 +84,22 @@ TEST(codegen, addition) {
     ASSERT_NE(asm_text.find("call printf"), string::npos);
 }
 
+TEST(codegen, comparison) {
+    cleanTestEnv();
+    string sa   = "../test/testdata/codegen/018_comparison.sa.json";
+    string asmf = "out/018_comparison.s";
+
+    string err = run_codegen(sa, asmf);
+    ASSERT_EQ(err, "");
+
+    string asm_text = readFile(asmf);
+    ASSERT_NE(asm_text.find("cmpq"),        string::npos);
+    ASSERT_NE(asm_text.find("setl"),        string::npos);
+    ASSERT_NE(asm_text.find("sete"),        string::npos);
+    ASSERT_NE(asm_text.find("movzbl"),      string::npos);
+    ASSERT_NE(asm_text.find("call printf"), string::npos);
+}
+
 TEST(codegen, convert_int32_to_int64) {
     cleanTestEnv();
     string sa   = "../test/testdata/codegen/006_convert.sa.json";

--- a/test/gen-ast-tester/basicTests.cpp
+++ b/test/gen-ast-tester/basicTests.cpp
@@ -261,6 +261,44 @@ TEST(gen_ast, export_func) {
 	ASSERT_TRUE(found_noexport);
 }
 
+TEST(gen_ast, if_stmt) {
+	cleanTestEnv();
+	string output = execTestCommand("bin/palan-gen-ast ../test/testdata/gen-ast/008_if_stmt.pa");
+	ASSERT_TRUE(checkerr(output));
+	json jout = json::parse(output);
+
+	// clamp function: body has 2 stmts (if + return)
+	bool found_clamp = false;
+	for (auto& f : jout["ast"]["functions"]) {
+		if (f["name"] != "clamp") continue;
+		found_clamp = true;
+		const auto& body = f["block"]["body"];
+		ASSERT_EQ(body.size(), 2u);
+		const auto& if_node = body[0];
+		ASSERT_EQ(if_node["stmt-type"], "if");
+		ASSERT_EQ(if_node["cond"]["expr-type"], "cmp");
+		ASSERT_EQ(if_node["cond"]["op"], "<");
+		ASSERT_TRUE(if_node.contains("then"));
+		ASSERT_FALSE(if_node.contains("else"));
+	}
+	ASSERT_TRUE(found_clamp);
+
+	// sign function: if-else
+	bool found_sign = false;
+	for (auto& f : jout["ast"]["functions"]) {
+		if (f["name"] != "sign") continue;
+		found_sign = true;
+		const auto& body = f["block"]["body"];
+		ASSERT_EQ(body.size(), 2u);
+		const auto& if_node = body[0];
+		ASSERT_EQ(if_node["stmt-type"], "if");
+		ASSERT_TRUE(if_node.contains("then"));
+		ASSERT_TRUE(if_node.contains("else"));
+		ASSERT_EQ(if_node["else"]["stmt-type"], "block");
+	}
+	ASSERT_TRUE(found_sign);
+}
+
 TEST(gen_ast, cli_tests) {
 	cleanTestEnv();
 	string output = execTestCommand("bin/palan-gen-ast -h");

--- a/test/gen-ast-tester/basicTests.cpp
+++ b/test/gen-ast-tester/basicTests.cpp
@@ -75,6 +75,31 @@ TEST(gen_ast, addition) {
 	ASSERT_TRUE(found_sub);
 }
 
+TEST(gen_ast, comparison) {
+	cleanTestEnv();
+	string output = execTestCommand("bin/palan-gen-ast ../test/testdata/build-mgr/005_comparison.pa");
+	ASSERT_TRUE(checkerr(output));
+	json jout = json::parse(output);
+
+	bool found_lt = false;
+	bool found_eq = false;
+	for (auto& stmt : jout["ast"]["statements"]) {
+		if (stmt["stmt-type"] != "expr") continue;
+		auto& body = stmt["body"];
+		if (body["expr-type"] == "call" && body["name"] == "printf") {
+			for (auto& arg : body["args"]) {
+				if (arg["expr-type"] != "cmp") continue;
+				ASSERT_EQ(arg["left"]["expr-type"],  "id");
+				ASSERT_EQ(arg["right"]["expr-type"], "id");
+				if (arg["op"] == "<")  found_lt = true;
+				if (arg["op"] == "==") found_eq = true;
+			}
+		}
+	}
+	ASSERT_TRUE(found_lt);
+	ASSERT_TRUE(found_eq);
+}
+
 TEST(gen_ast, var_decl_int32) {
 	cleanTestEnv();
 	string output = execTestCommand("bin/palan-gen-ast ../test/testdata/build-mgr/004_int32_widening.pa");

--- a/test/gen-ast-tester/basicTests.cpp
+++ b/test/gen-ast-tester/basicTests.cpp
@@ -51,7 +51,8 @@ TEST(gen_ast, addition) {
 	ASSERT_TRUE(checkerr(output));
 	json jout = json::parse(output);
 
-	bool found = false;
+	bool found_add = false;
+	bool found_sub = false;
 	for (auto& stmt : jout["ast"]["statements"]) {
 		if (stmt["stmt-type"] != "expr") continue;
 		auto& body = stmt["body"];
@@ -60,12 +61,18 @@ TEST(gen_ast, addition) {
 				if (arg["expr-type"] == "add") {
 					ASSERT_EQ(arg["left"]["expr-type"],  "id");
 					ASSERT_EQ(arg["right"]["expr-type"], "id");
-					found = true;
+					found_add = true;
+				}
+				if (arg["expr-type"] == "sub") {
+					ASSERT_EQ(arg["left"]["expr-type"],  "id");
+					ASSERT_EQ(arg["right"]["expr-type"], "id");
+					found_sub = true;
 				}
 			}
 		}
 	}
-	ASSERT_TRUE(found);
+	ASSERT_TRUE(found_add);
+	ASSERT_TRUE(found_sub);
 }
 
 TEST(gen_ast, var_decl_int32) {

--- a/test/sa-tester/basicTests.cpp
+++ b/test/sa-tester/basicTests.cpp
@@ -78,25 +78,34 @@ TEST(sa, addition_sa) {
 
 	ASSERT_TRUE(jout.is_object());
 
-	bool found = false;
+	bool found_add = false;
+	bool found_sub = false;
 	for (auto& stmt : jout["statements"]) {
 		if (stmt["stmt-type"] != "expr") continue;
 		auto& body = stmt["body"];
 		if (body["expr-type"] == "call" && body["name"] == "printf") {
 			for (auto& arg : body["args"]) {
-				if (arg["expr-type"] != "add") continue;
-				// addition: id nodes present
-				ASSERT_EQ(arg["left"]["expr-type"],  "id");
-				ASSERT_EQ(arg["right"]["expr-type"], "id");
-				// value_type_on_expressions: value-type annotated
-				ASSERT_EQ(arg["value-type"]["type-name"],          "int64");
-				ASSERT_EQ(arg["left"]["value-type"]["type-name"],  "int64");
-				ASSERT_EQ(arg["right"]["value-type"]["type-name"], "int64");
-				found = true;
+				if (arg["expr-type"] == "add") {
+					ASSERT_EQ(arg["left"]["expr-type"],  "id");
+					ASSERT_EQ(arg["right"]["expr-type"], "id");
+					ASSERT_EQ(arg["value-type"]["type-name"],          "int64");
+					ASSERT_EQ(arg["left"]["value-type"]["type-name"],  "int64");
+					ASSERT_EQ(arg["right"]["value-type"]["type-name"], "int64");
+					found_add = true;
+				}
+				if (arg["expr-type"] == "sub") {
+					ASSERT_EQ(arg["left"]["expr-type"],  "id");
+					ASSERT_EQ(arg["right"]["expr-type"], "id");
+					ASSERT_EQ(arg["value-type"]["type-name"],          "int64");
+					ASSERT_EQ(arg["left"]["value-type"]["type-name"],  "int64");
+					ASSERT_EQ(arg["right"]["value-type"]["type-name"], "int64");
+					found_sub = true;
+				}
 			}
 		}
 	}
-	ASSERT_TRUE(found);
+	ASSERT_TRUE(found_add);
+	ASSERT_TRUE(found_sub);
 }
 
 TEST(sa, convert_widening_sa) {

--- a/test/sa-tester/basicTests.cpp
+++ b/test/sa-tester/basicTests.cpp
@@ -455,6 +455,41 @@ TEST(sa, block_cinclude_scope) {
 	ASSERT_EQ(jout["statements"][0]["body"][0]["body"]["func-type"], "c");
 }
 
+TEST(sa, if_stmt_sa) {
+	cleanTestEnv();
+	json jout = run_sa("../test/testdata/sa/036_if_stmt.pa");
+
+	ASSERT_TRUE(jout.is_object());
+	bool found_if = false;
+	for (auto& stmt : jout["statements"]) {
+		if (stmt["stmt-type"] != "if") continue;
+		found_if = true;
+		// cond is a cmp expression with value-type int32
+		ASSERT_EQ(stmt["cond"]["expr-type"], "cmp");
+		ASSERT_EQ(stmt["cond"]["value-type"]["type-name"], "int32");
+		// then block contains a printf call
+		ASSERT_EQ(stmt["then"]["stmt-type"], "block");
+		ASSERT_FALSE(stmt.contains("else"));
+	}
+	ASSERT_TRUE(found_if);
+}
+
+TEST(sa, if_else_stmt_sa) {
+	cleanTestEnv();
+	json jout = run_sa("../test/testdata/sa/037_if_else_stmt.pa");
+
+	ASSERT_TRUE(jout.is_object());
+	bool found_if = false;
+	for (auto& stmt : jout["statements"]) {
+		if (stmt["stmt-type"] != "if") continue;
+		found_if = true;
+		ASSERT_EQ(stmt["then"]["stmt-type"], "block");
+		ASSERT_TRUE(stmt.contains("else"));
+		ASSERT_EQ(stmt["else"]["stmt-type"], "block");
+	}
+	ASSERT_TRUE(found_if);
+}
+
 TEST(sa, block_func_def) {
 	cleanTestEnv();
 	json jout = run_sa("../test/testdata/sa/017_block_func_def.pa");

--- a/test/sa-tester/basicTests.cpp
+++ b/test/sa-tester/basicTests.cpp
@@ -108,6 +108,32 @@ TEST(sa, addition_sa) {
 	ASSERT_TRUE(found_sub);
 }
 
+TEST(sa, comparison_sa) {
+	cleanTestEnv();
+	json jout = run_sa("../test/testdata/build-mgr/005_comparison.pa");
+
+	ASSERT_TRUE(jout.is_object());
+
+	bool found_lt = false;
+	bool found_eq = false;
+	for (auto& stmt : jout["statements"]) {
+		if (stmt["stmt-type"] != "expr") continue;
+		auto& body = stmt["body"];
+		if (body["expr-type"] == "call" && body["name"] == "printf") {
+			for (auto& arg : body["args"]) {
+				if (arg["expr-type"] != "cmp") continue;
+				ASSERT_EQ(arg["value-type"]["type-name"], "int32");
+				ASSERT_EQ(arg["left"]["value-type"]["type-name"],  "int64");
+				ASSERT_EQ(arg["right"]["value-type"]["type-name"], "int64");
+				if (arg["op"] == "<")  found_lt = true;
+				if (arg["op"] == "==") found_eq = true;
+			}
+		}
+	}
+	ASSERT_TRUE(found_lt);
+	ASSERT_TRUE(found_eq);
+}
+
 TEST(sa, convert_widening_sa) {
 	cleanTestEnv();
 	json jout = run_sa("../test/testdata/sa/001_convert_widening.pa");

--- a/test/testdata/build-mgr/003_addition.pa
+++ b/test/testdata/build-mgr/003_addition.pa
@@ -2,3 +2,4 @@ cinclude <stdio.h>;
 int64 x = 10;
 int64 y = 20;
 printf("%lld\n", x + y);
+printf("%lld\n", x - y);

--- a/test/testdata/build-mgr/005_comparison.pa
+++ b/test/testdata/build-mgr/005_comparison.pa
@@ -1,0 +1,5 @@
+cinclude <stdio.h>;
+int64 x = 3;
+int64 y = 5;
+printf("%d\n", x < y);
+printf("%d\n", x == y);

--- a/test/testdata/build-mgr/006_fibonacci.pa
+++ b/test/testdata/build-mgr/006_fibonacci.pa
@@ -1,0 +1,10 @@
+cinclude <stdio.h>;
+
+func fib(int64 n) -> int64 {
+    if n <= 1 {
+        return n;
+    }
+    return fib(n - 1) + fib(n - 2);
+}
+
+printf("%ld\n", fib(10));

--- a/test/testdata/build-mgr/101_basic_expr.pa
+++ b/test/testdata/build-mgr/101_basic_expr.pa
@@ -38,3 +38,18 @@ cinclude <stdio.h>;
     int32 b = 50;
     printf("%hd %hhd %hd %hhd\n", int16(a), int8(a), int16(b), int8(b));
 }
+
+// 008: subtraction
+{
+    int64 x = 10;
+    int64 y = 3;
+    printf("%lld\n", x - y);
+}
+
+// 009: comparison
+{
+    int64 x = 3;
+    int64 y = 5;
+    printf("%d %d %d\n", x < y, x <= y, x > y);
+    printf("%d %d %d\n", x >= y, x == y, x != y);
+}

--- a/test/testdata/codegen/005_addition.sa.json
+++ b/test/testdata/codegen/005_addition.sa.json
@@ -35,6 +35,23 @@
           }
         ]
       }
+    },
+    {
+      "stmt-type": "expr",
+      "body": {
+        "expr-type": "call",
+        "func-type": "c",
+        "name": "printf",
+        "args": [
+          { "expr-type": "lit-str", "label": ".str0", "value-type": {"type-kind": "pntr", "base-type": {"type-kind": "prim", "type-name": "uint8"}} },
+          {
+            "expr-type": "sub",
+            "value-type": {"type-kind": "prim", "type-name": "int64"},
+            "left":  { "expr-type": "id", "name": "x", "var-type": {"type-kind": "prim", "type-name": "int64"}, "value-type": {"type-kind": "prim", "type-name": "int64"} },
+            "right": { "expr-type": "id", "name": "y", "var-type": {"type-kind": "prim", "type-name": "int64"}, "value-type": {"type-kind": "prim", "type-name": "int64"} }
+          }
+        ]
+      }
     }
   ]
 }

--- a/test/testdata/codegen/018_comparison.sa.json
+++ b/test/testdata/codegen/018_comparison.sa.json
@@ -1,0 +1,59 @@
+{
+  "original": "/test/comparison.pa",
+  "str-literals": [
+    { "label": ".str0", "value": "%d\n" }
+  ],
+  "statements": [
+    {
+      "stmt-type": "var-decl",
+      "vars": [
+        {
+          "name": "x",
+          "var-type": { "type-kind": "prim", "type-name": "int64" },
+          "init": { "expr-type": "lit-int", "value": "3", "value-type": {"type-kind": "prim", "type-name": "int64"} }
+        },
+        {
+          "name": "y",
+          "var-type": { "type-kind": "prim", "type-name": "int64" },
+          "init": { "expr-type": "lit-int", "value": "5", "value-type": {"type-kind": "prim", "type-name": "int64"} }
+        }
+      ]
+    },
+    {
+      "stmt-type": "expr",
+      "body": {
+        "expr-type": "call",
+        "func-type": "c",
+        "name": "printf",
+        "args": [
+          { "expr-type": "lit-str", "label": ".str0", "value-type": {"type-kind": "pntr", "base-type": {"type-kind": "prim", "type-name": "uint8"}} },
+          {
+            "expr-type": "cmp",
+            "op": "<",
+            "value-type": {"type-kind": "prim", "type-name": "int32"},
+            "left":  { "expr-type": "id", "name": "x", "var-type": {"type-kind": "prim", "type-name": "int64"}, "value-type": {"type-kind": "prim", "type-name": "int64"} },
+            "right": { "expr-type": "id", "name": "y", "var-type": {"type-kind": "prim", "type-name": "int64"}, "value-type": {"type-kind": "prim", "type-name": "int64"} }
+          }
+        ]
+      }
+    },
+    {
+      "stmt-type": "expr",
+      "body": {
+        "expr-type": "call",
+        "func-type": "c",
+        "name": "printf",
+        "args": [
+          { "expr-type": "lit-str", "label": ".str0", "value-type": {"type-kind": "pntr", "base-type": {"type-kind": "prim", "type-name": "uint8"}} },
+          {
+            "expr-type": "cmp",
+            "op": "==",
+            "value-type": {"type-kind": "prim", "type-name": "int32"},
+            "left":  { "expr-type": "id", "name": "x", "var-type": {"type-kind": "prim", "type-name": "int64"}, "value-type": {"type-kind": "prim", "type-name": "int64"} },
+            "right": { "expr-type": "id", "name": "y", "var-type": {"type-kind": "prim", "type-name": "int64"}, "value-type": {"type-kind": "prim", "type-name": "int64"} }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/testdata/codegen/019_if_stmt.sa.json
+++ b/test/testdata/codegen/019_if_stmt.sa.json
@@ -1,0 +1,42 @@
+{
+  "original": "/test/if_stmt.pa",
+  "str-literals": [
+    { "label": ".str0", "value": "yes\n" }
+  ],
+  "statements": [
+    {
+      "stmt-type": "var-decl",
+      "vars": [
+        {
+          "name": "x",
+          "var-type": { "type-kind": "prim", "type-name": "int64" },
+          "init": { "expr-type": "lit-int", "value": "3", "value-type": { "type-kind": "prim", "type-name": "int64" } }
+        }
+      ]
+    },
+    {
+      "stmt-type": "if",
+      "cond": {
+        "expr-type": "cmp",
+        "op": "<",
+        "value-type": { "type-kind": "prim", "type-name": "int32" },
+        "left":  { "expr-type": "id", "name": "x", "var-type": { "type-kind": "prim", "type-name": "int64" }, "value-type": { "type-kind": "prim", "type-name": "int64" } },
+        "right": { "expr-type": "lit-int", "value": "5", "value-type": { "type-kind": "prim", "type-name": "int64" } }
+      },
+      "then": {
+        "stmt-type": "block",
+        "body": [
+          {
+            "stmt-type": "expr",
+            "body": {
+              "expr-type": "call", "func-type": "c", "name": "printf",
+              "args": [
+                { "expr-type": "lit-str", "label": ".str0", "value-type": { "type-kind": "pntr", "base-type": { "type-kind": "prim", "type-name": "uint8" } } }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/testdata/codegen/020_if_else_stmt.sa.json
+++ b/test/testdata/codegen/020_if_else_stmt.sa.json
@@ -1,0 +1,57 @@
+{
+  "original": "/test/if_else_stmt.pa",
+  "str-literals": [
+    { "label": ".str0", "value": "lt\n" },
+    { "label": ".str1", "value": "ge\n" }
+  ],
+  "statements": [
+    {
+      "stmt-type": "var-decl",
+      "vars": [
+        {
+          "name": "x",
+          "var-type": { "type-kind": "prim", "type-name": "int64" },
+          "init": { "expr-type": "lit-int", "value": "3", "value-type": { "type-kind": "prim", "type-name": "int64" } }
+        }
+      ]
+    },
+    {
+      "stmt-type": "if",
+      "cond": {
+        "expr-type": "cmp",
+        "op": "<",
+        "value-type": { "type-kind": "prim", "type-name": "int32" },
+        "left":  { "expr-type": "id", "name": "x", "var-type": { "type-kind": "prim", "type-name": "int64" }, "value-type": { "type-kind": "prim", "type-name": "int64" } },
+        "right": { "expr-type": "lit-int", "value": "5", "value-type": { "type-kind": "prim", "type-name": "int64" } }
+      },
+      "then": {
+        "stmt-type": "block",
+        "body": [
+          {
+            "stmt-type": "expr",
+            "body": {
+              "expr-type": "call", "func-type": "c", "name": "printf",
+              "args": [
+                { "expr-type": "lit-str", "label": ".str0", "value-type": { "type-kind": "pntr", "base-type": { "type-kind": "prim", "type-name": "uint8" } } }
+              ]
+            }
+          }
+        ]
+      },
+      "else": {
+        "stmt-type": "block",
+        "body": [
+          {
+            "stmt-type": "expr",
+            "body": {
+              "expr-type": "call", "func-type": "c", "name": "printf",
+              "args": [
+                { "expr-type": "lit-str", "label": ".str1", "value-type": { "type-kind": "pntr", "base-type": { "type-kind": "prim", "type-name": "uint8" } } }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/testdata/gen-ast/008_if_stmt.pa
+++ b/test/testdata/gen-ast/008_if_stmt.pa
@@ -1,0 +1,15 @@
+func clamp(int64 x) -> int64 {
+    if x < 0 {
+        return 0;
+    }
+    return x;
+}
+
+func sign(int64 x) -> int64 {
+    if x < 0 {
+        return 0 - 1;
+    } else {
+        return 1;
+    }
+    return 0;
+}

--- a/test/testdata/sa/036_if_stmt.pa
+++ b/test/testdata/sa/036_if_stmt.pa
@@ -1,0 +1,5 @@
+cinclude <stdio.h>;
+int64 x = 3;
+if x < 5 {
+    printf("yes\n");
+}

--- a/test/testdata/sa/037_if_else_stmt.pa
+++ b/test/testdata/sa/037_if_else_stmt.pa
@@ -1,0 +1,7 @@
+cinclude <stdio.h>;
+int64 x = 3;
+if x < 5 {
+    printf("lt\n");
+} else {
+    printf("ge\n");
+}


### PR DESCRIPTION
## Summary

- Subtraction operator `-` implemented across full pipeline (gen-ast → sa → codegen)
- Comparison operators `<`, `<=`, `>`, `>=`, `==`, `!=` implemented across full pipeline
- `if` / `if-else` statements implemented across full pipeline
- Fibonacci end-to-end test: `fib(10) == 55` verified via build-mgr-tester
- Bug fixes: `PlnRegAlloc` missing `Sub`/`Cmp` VReg tracking; `PlnX86CodeGen` `MovImm` to stack slot; `Add`/`Sub` spilled-dst mem-mem via scratch `%rax`
- Docs: `PalanReference.md` §5/§10 updated; `ASTSpec.md`, `SASpec.md` updated; version bumped to 0.1.9

## Test plan

- [ ] `make` — all test suites pass (gen-ast, sa, codegen, build-mgr)
- [ ] `bin/build-mgr-tester --gtest_filter=build_mgr.fibonacci` outputs `55`
- [ ] `bin/palan-codegen --version` reports `0.1.9`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)