### PR TITLE
feat: v0.1.11 — while loops, void functions, Collatz/FizzBuzz

### DIFF
--- a/.claude/skills/coverage/SKILL.md
+++ b/.claude/skills/coverage/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: coverage
+description: Use this skill when the user mentions coverage, カバレッジ, uncovered lines, wants to check or improve test coverage for a specific file or component, or asks to run coverage-related make targets.
+---
+
+## Coverage Build Directory
+
+Coverage builds use `build-cov/` (separate from `build/`). `build-cov/` persists between runs — only `.gcda` files are cleared before each run, so incremental builds are fast after the first.
+
+## Make Targets
+
+| Target | Tests run | lcov filter | When to use |
+|--------|-----------|-------------|-------------|
+| `make coverage` | all testers | `src/*` | Full report; PR review, overall health check |
+| `make coverage-codegen` | codegen-tester + build-mgr-tester | `src/codegen/*` | Working on PlnX86CodeGen, PlnVCodeGen, PlnRegAlloc |
+| `make coverage-sa` | sa-tester + sa-unit-tester | `src/semantic-anlyzr/*` | Working on PlnSemanticAnalyzer |
+| `make coverage-reset` | — | — | Force full rebuild of build-cov/ (e.g., after CMakeLists change) |
+
+Run **foreground only** — do not use `run_in_background: true` (prevents duplicate builds).
+
+## Checking Coverage Results
+
+**Overall summary** (totals only — reliable):
+```bash
+lcov --summary build-cov/lcov.info --rc branch_coverage=1
+```
+
+**Per-file line coverage** (parse lcov.info directly — `lcov --list` is unreliable with lcov 2.0):
+```bash
+awk '/^SF:/{f=$0} /^LF:/{lf=$0} /^LH:/{lh=$0} /^end_of_record/{
+  sub(/^SF:/,"",f); sub(/^LF:/,"",lf); sub(/^LH:/,"",lh);
+  printf "%-60s %s/%s\n", f, lh, lf}' build-cov/lcov.info
+```
+
+> **Note:** `lcov --list` in lcov 2.0 displays incorrect per-file percentages (e.g., 5.4% when actual is 90%). Use `lcov --summary` for totals and parse `lcov.info` directly for per-file stats.
+
+## Viewing Uncovered Lines in a Specific File
+
+Use `gcov` from inside `build-cov/` to avoid creating `.gcov` files in the repo root:
+
+```bash
+# Example: PlnX86CodeGen.cpp
+cd build-cov && gcov -o src/codegen/CMakeFiles/palan-codegen.dir/ \
+     ../src/codegen/PlnX86CodeGen.cpp.gcno
+```
+
+This writes `PlnX86CodeGen.cpp.gcov` inside `build-cov/`.
+Read it with the Read tool — lines prefixed with `#####:` are uncovered.
+
+**gcov object directory by component (paths relative to build-cov/):**
+
+| Source file | -o path |
+|-------------|---------|
+| `src/codegen/*.cpp` | `src/codegen/CMakeFiles/palan-codegen.dir/` |
+| `src/semantic-anlyzr/*.cpp` | `src/semantic-anlyzr/CMakeFiles/palan-sa.dir/` |
+| `src/c2ast/*.cpp` | `src/c2ast/CMakeFiles/palan-c2ast.dir/` |
+| `src/gen-ast/*.cpp` | `src/gen-ast/CMakeFiles/palan-gen-ast.dir/` |
+| `src/build-mgr/*.cpp` | `src/build-mgr/CMakeFiles/palan.dir/` |
+
+## Workflow
+
+1. Run the appropriate `make coverage-*` target
+2. Check per-file % by parsing `lcov.info` directly (see above)
+3. For files with low coverage, run `gcov` from inside `build-cov/` and read the `.gcov` file to identify uncovered lines
+4. Write tests targeting those lines, then re-run the coverage target

--- a/doc/ASTSpec.md
+++ b/doc/ASTSpec.md
@@ -112,7 +112,7 @@ Used in `func-def` bodies and standalone block statements.
 
 Statement model
 ---------------
-- stmt-type\* - Statement type: "import" "cinclude" "expr" "var-decl" "assign" "return" "tapple-decl" "block" "if"
+- stmt-type\* - Statement type: "import" "cinclude" "expr" "var-decl" "assign" "return" "tapple-decl" "block" "if" "while"
 - loc\* - Location Array (omitted for "not-impl")
   1. import - import module statement
     - path-type\* - Path type string: "src" "inc"
@@ -145,6 +145,9 @@ Statement model
     - cond\* - Condition expression model
     - then\* - Then-block object (block statement body)
     - else - Else-block object or nested if statement (omitted when absent)
+  10. while - while loop statement
+    - cond\* - Condition expression model
+    - body\* - Statement model list (raw array, no block wrapper)
 
 Expression model
 ----------------

--- a/doc/PalanReference.md
+++ b/doc/PalanReference.md
@@ -1,6 +1,6 @@
 # Palan Language Reference
 
-**Version:** v0.1.9
+**Version:** v0.1.11
 
 Palan is a compiled systems programming language designed as a simpler, safer, and more enjoyable alternative to C. It targets developers who want low-level control and direct access to C libraries, without the sharp edges of C syntax. Palan code compiles to native x86-64 binaries via AT&T assembly, with no runtime overhead.
 
@@ -50,6 +50,7 @@ printf("%ld %ld\n", ab, bc);   // 3 5
 11. [Block Statements](#11-block-statements)
 12. [Modules (import / export)](#12-modules-import--export)
 13. [Program Structure](#13-program-structure)
+14. [While Loops](#14-while-loops)
 
 ---
 
@@ -364,4 +365,39 @@ printf("%lld\n", x);
 - Top-level statements execute as the `_start` entry point.
 - User-defined functions can be placed before or after top-level statements.
 - `return` is not valid at top-level. To exit early, call `exit()` from `<stdlib.h>`.
+
+---
+
+## 14. While Loops
+
+`while cond { body }` repeats `body` as long as `cond` is non-zero.
+
+```palan
+cinclude <stdio.h>;
+
+int64 i = 1;
+while i <= 5 {
+    printf("%ld\n", i);
+    i + 1 -> i;
+}
+```
+
+The condition is evaluated before each iteration. The loop exits when the condition is zero (false).
+
+```palan
+cinclude <stdio.h>;
+
+func fizzbuzz(int64 n) {
+    int64 i = 1;
+    while i <= n {
+        if i % 15 == 0 { printf("FizzBuzz\n"); }
+        else if i % 3 == 0 { printf("Fizz\n"); }
+        else if i % 5 == 0 { printf("Buzz\n"); }
+        else { printf("%ld\n", i); }
+        i + 1 -> i;
+    }
+}
+
+fizzbuzz(20);
+```
 

--- a/doc/SASpec.md
+++ b/doc/SASpec.md
@@ -63,6 +63,11 @@ Same structure as AST statements (see ASTSpec.md) with the following differences
   - then\*: then-block (same structure as block stmt body in ASTSpec.md)
   - else: else-block or nested if statement (omitted when absent)
 
+- **while** - while loop statement
+  - stmt-type\*: "while"
+  - cond\*: SA-annotated condition expression (value-type present; integer expected)
+  - body\*: SA-annotated statement list (raw array; variables declared inside are scoped to the loop body)
+
 Additional statement kinds emitted by SA:
 
 - **assign** - assignment statement

--- a/doc/SpecAndDesign.md
+++ b/doc/SpecAndDesign.md
@@ -6,37 +6,56 @@ This document specifies the goals, scope, architecture, and requirements for the
 ## 2. Goals
 - Palan aims to be a simpler, safer, and more enjoyable programming language alternative to C.
 
-### 2.1 Iteration Goal (2026-03-26)
-version: 0.1.10
-- This iteration implements the language features required to run an abs/gcd/lcm sample with a multi-argument printf.
-- Unary minus `-expr` is added (gen-ast → sa → codegen full pipeline).
-- Arithmetic operators `*`, `/`, `%` are added (same pipeline).
-- Stack-based argument passing (7th argument and beyond) is supported for function calls.
-- The following sample is verified by an end-to-end build-mgr test:
+### 2.1 Iteration Goal (2026-03-30)
+version: 0.1.11
+- This iteration implements `while` loops and void functions (no return value).
+- The following two samples are verified by end-to-end build-mgr tests.
+
+#### Collatz sequence
 
 ```palan
 cinclude <stdio.h>;
 
-func abs(int64 x) -> int64 {
-    if x < 0 { return -x; }
-    return x;
+func collatz_steps(int64 n) -> int64 {
+    int64 steps = 0;
+    while n != 1 {
+        if n % 2 == 0 { n / 2 -> n; }
+        else { n * 3 + 1 -> n; }
+        steps + 1 -> steps;
+    }
+    return steps;
 }
 
-func gcd(int64 a, int64 b) -> int64 {
-    if b == 0 { return a; }
-    return gcd(b, a % b);
-}
-
-func lcm(int64 a, int64 b) -> int64 {
-    return a / gcd(a, b) * b;
-}
-
-printf("abs=%ld gcd=%ld lcm=%ld abs=%ld gcd=%ld lcm=%ld\n",
-    abs(-42), gcd(12, 8), lcm(4, 6),
-    abs(-7),  gcd(48, 18), lcm(6, 10));
+printf("collatz(27) = %ld\n", collatz_steps(27));
+printf("collatz(871) = %ld\n", collatz_steps(871));
 ```
 
-Expected output: `abs=42 gcd=4 lcm=12 abs=7 gcd=6 lcm=30`
+Expected output:
+```
+collatz(27) = 111
+collatz(871) = 178
+```
+
+#### FizzBuzz (void function)
+
+```palan
+cinclude <stdio.h>;
+
+func fizzbuzz(int64 n) {
+    int64 i = 1;
+    while i <= n {
+        if i % 15 == 0 { printf("FizzBuzz\n"); }
+        else if i % 3 == 0 { printf("Fizz\n"); }
+        else if i % 5 == 0 { printf("Buzz\n"); }
+        else { printf("%ld\n", i); }
+        i + 1 -> i;
+    }
+}
+
+fizzbuzz(20);
+```
+
+Expected output: FizzBuzz for 1–20
 
 
 ## 3. Command-line Tools' Responsibilities and Design

--- a/src/codegen/PlnDeserialize.cpp
+++ b/src/codegen/PlnDeserialize.cpp
@@ -160,6 +160,8 @@ static unique_ptr<Stmt> deserializeStmt(const json& j)
     if (stmt_type == "assign") {
         auto s = make_unique<AssignStmt>();
         s->name  = j["name"];
+        s->type  = j["value"].contains("value-type") ? toVRegType(j["value"]["value-type"])
+                                                      : VRegType::Int64;
         s->value = deserializeExpr(j["value"]);
         return s;
     }

--- a/src/codegen/PlnDeserialize.cpp
+++ b/src/codegen/PlnDeserialize.cpp
@@ -204,6 +204,14 @@ static unique_ptr<Stmt> deserializeStmt(const json& j)
         }
         return s;
     }
+    if (stmt_type == "while") {
+        auto s = make_unique<WhileStmt>();
+        s->cond = deserializeExpr(j["cond"]);
+        auto body = make_unique<BlockStmt>();
+        body->body = deserializeStatements(j["body"]);
+        s->body = move(body);
+        return s;
+    }
     if (stmt_type == "not-impl") {
         return nullptr;
     }

--- a/src/codegen/PlnNode.h
+++ b/src/codegen/PlnNode.h
@@ -172,7 +172,8 @@ struct VarDeclStmt : Stmt {
 
 struct AssignStmt : Stmt {
     AssignStmt() : Stmt(StmtKind::Assign) {}
-    string           name;   // destination variable name
+    string           name;                       // destination variable name
+    VRegType         type = VRegType::Int64;     // type of the assigned value
     unique_ptr<Expr> value;
 };
 

--- a/src/codegen/PlnNode.h
+++ b/src/codegen/PlnNode.h
@@ -144,6 +144,7 @@ enum class StmtKind {
     TappleDecl,
     Block,
     If,
+    While,
 };
 
 struct Stmt {
@@ -198,6 +199,12 @@ struct IfStmt : Stmt {
     unique_ptr<Expr> cond;
     unique_ptr<Stmt> thenStmt;  // always BlockStmt
     unique_ptr<Stmt> elseStmt;  // nullptr | BlockStmt | IfStmt (else-if chain)
+};
+
+struct WhileStmt : Stmt {
+    WhileStmt() : Stmt(StmtKind::While) {}
+    unique_ptr<Expr> cond;
+    unique_ptr<Stmt> body;  // always BlockStmt
 };
 
 // -------- Module --------

--- a/src/codegen/PlnRegAlloc.cpp
+++ b/src/codegen/PlnRegAlloc.cpp
@@ -20,6 +20,7 @@ RegAllocResult allocateRegisters(const VFunc& func, const PhysRegs& phys)
 
     vector<int> call_indices;    // instruction indices of all CallC/CallPln
     vector<int> divmod_indices;  // instruction indices of all Div/Mod (%rax/%rdx clobbered)
+    map<string, int> label_idx;  // label name → instruction index (for loop detection)
 
     for (int i = 0; i < (int)func.instrs.size(); i++) {
         auto& instr = func.instrs[i];
@@ -106,6 +107,24 @@ RegAllocResult allocateRegisters(const VFunc& func, const PhysRegs& phys)
             }
         } else if (auto* cj = get_if<CondJmp>(&instr)) {
             meta[cj->cond].last_any_use = max(meta[cj->cond].last_any_use, i);
+        } else if (auto* lbl = get_if<Label>(&instr)) {
+            label_idx[lbl->name] = i;
+        } else if (auto* mv = get_if<Mov>(&instr)) {
+            // Mov copies src into dst (the variable's canonical VReg).
+            // dst is always isVar (allocated by Pass B); only src needs tracking here.
+            meta[mv->src].last_any_use = max(meta[mv->src].last_any_use, i);
+        }
+    }
+
+    // Collect loop regions: backward jumps define [loop_start_label_idx, jmp_idx].
+    // A parameter used inside a loop that also contains a call effectively crosses
+    // that call (next iteration re-executes the use after the call).
+    vector<pair<int,int>> loop_regions;
+    for (int i = 0; i < (int)func.instrs.size(); i++) {
+        if (auto* j = get_if<Jmp>(&func.instrs[i])) {
+            auto it = label_idx.find(j->label);
+            if (it != label_idx.end() && it->second < i)
+                loop_regions.push_back({it->second, i});
         }
     }
 
@@ -169,6 +188,25 @@ RegAllocResult allocateRegisters(const VFunc& func, const PhysRegs& phys)
                 break;
             }
         }
+        // Loop check: if a use and a call both appear in the same loop body,
+        // the backward jump causes re-execution of the use after the call.
+        if (!crosses_call) {
+            for (auto& [ls, le] : loop_regions) {
+                bool use_in_loop = (m.last_any_use >= ls && m.last_any_use <= le);
+                if (!use_in_loop) {
+                    for (auto& [ci, pos] : m.call_uses)
+                        if (ci >= ls && ci <= le) { use_in_loop = true; break; }
+                }
+                if (!use_in_loop) continue;
+                for (int c_idx : call_indices) {
+                    if (c_idx >= ls && c_idx <= le) {
+                        crosses_call = true;
+                        break;
+                    }
+                }
+                if (crosses_call) break;
+            }
+        }
 
         if (crosses_call) {
             allocCalleeSavedOrStack(vreg, type);
@@ -185,7 +223,7 @@ RegAllocResult allocateRegisters(const VFunc& func, const PhysRegs& phys)
 
     for (auto& [vreg, m] : meta) {
         if (result.count(vreg)) continue;  // already bound (e.g., param pre-binding)
-        if (m.isVar && m.call_uses.empty()) continue;  // Pass B handles stack-only isVar
+        if (m.isVar) continue;  // Pass B always allocates isVar to stack
 
         if (m.call_uses.empty()) {
             if (m.isRetValue && numRetValues == 1) {

--- a/src/codegen/PlnRegAlloc.cpp
+++ b/src/codegen/PlnRegAlloc.cpp
@@ -4,6 +4,11 @@
 
 using namespace std;
 
+// Visitor helper: overloaded{f1, f2, ...} dispatches std::visit to the matching overload.
+// All VInstr types must be handled; omitting one causes a compile error.
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
 RegAllocResult allocateRegisters(const VFunc& func, const PhysRegs& phys)
 {
     // Step 1: Collect VReg metadata.
@@ -11,10 +16,9 @@ RegAllocResult allocateRegisters(const VFunc& func, const PhysRegs& phys)
         VRegType type         = VRegType::Int64;
         int      def_idx      = -1;
         bool     isVar        = false;   // true if defined by InitVar (variable)
-        int      last_any_use = -1;      // last use by Add (non-call) instructions
+        int      last_any_use = -1;      // last use by non-call-argument instructions
         vector<pair<int,int>> call_uses; // (call_instr_idx, arg_position)
         bool     isRetValue   = false;   // true if used by RetPln
-        int      retIdx       = 0;       // position in RetPln rets[]
     };
     map<VReg, VRegMeta> meta;
 
@@ -24,96 +28,67 @@ RegAllocResult allocateRegisters(const VFunc& func, const PhysRegs& phys)
 
     for (int i = 0; i < (int)func.instrs.size(); i++) {
         auto& instr = func.instrs[i];
-        if (auto* l = get_if<LeaLabel>(&instr)) {
-            meta[l->dst].def_idx = i;
-            meta[l->dst].type    = l->type;
-        } else if (auto* m = get_if<MovImm>(&instr)) {
-            meta[m->dst].def_idx = i;
-            meta[m->dst].type    = m->type;
-        } else if (auto* v = get_if<InitVar>(&instr)) {
-            meta[v->dst].def_idx = i;
-            meta[v->dst].type    = v->type;
-            meta[v->dst].isVar   = true;
-        } else if (auto* c = get_if<Convert>(&instr)) {
-            meta[c->dst].def_idx = i;
-            meta[c->dst].type    = c->to;
-            meta[c->src].last_any_use = max(meta[c->src].last_any_use, i);
-        } else if (auto* a = get_if<Add>(&instr)) {
-            meta[a->dst].def_idx = i;
-            meta[a->dst].type    = a->type;
-            meta[a->lhs].last_any_use = max(meta[a->lhs].last_any_use, i);
-            meta[a->rhs].last_any_use = max(meta[a->rhs].last_any_use, i);
-        } else if (auto* s = get_if<Sub>(&instr)) {
-            meta[s->dst].def_idx = i;
-            meta[s->dst].type    = s->type;
-            meta[s->lhs].last_any_use = max(meta[s->lhs].last_any_use, i);
-            meta[s->rhs].last_any_use = max(meta[s->rhs].last_any_use, i);
-        } else if (auto* m = get_if<Mul>(&instr)) {
-            meta[m->dst].def_idx = i;
-            meta[m->dst].type    = m->type;
-            meta[m->lhs].last_any_use = max(meta[m->lhs].last_any_use, i);
-            meta[m->rhs].last_any_use = max(meta[m->rhs].last_any_use, i);
-        } else if (auto* d = get_if<Div>(&instr)) {
-            divmod_indices.push_back(i);
-            meta[d->dst].def_idx = i;
-            meta[d->dst].type    = d->type;
-            meta[d->lhs].last_any_use = max(meta[d->lhs].last_any_use, i);
-            meta[d->rhs].last_any_use = max(meta[d->rhs].last_any_use, i);
-        } else if (auto* md = get_if<Mod>(&instr)) {
-            divmod_indices.push_back(i);
-            meta[md->dst].def_idx = i;
-            meta[md->dst].type    = md->type;
-            meta[md->lhs].last_any_use = max(meta[md->lhs].last_any_use, i);
-            meta[md->rhs].last_any_use = max(meta[md->rhs].last_any_use, i);
-        } else if (auto* n = get_if<Neg>(&instr)) {
-            meta[n->dst].def_idx = i;
-            meta[n->dst].type    = n->type;
-            meta[n->src].last_any_use = max(meta[n->src].last_any_use, i);
-        } else if (auto* cm = get_if<Cmp>(&instr)) {
-            meta[cm->dst].def_idx = i;
-            meta[cm->dst].type    = VRegType::Int32;
-            meta[cm->lhs].last_any_use = max(meta[cm->lhs].last_any_use, i);
-            meta[cm->rhs].last_any_use = max(meta[cm->rhs].last_any_use, i);
-        } else if (auto* c = get_if<CallC>(&instr)) {
-            call_indices.push_back(i);
-            for (int j = 0; j < (int)c->args.size(); j++) {
+
+        auto setDef = [&](VReg dst, VRegType type) {
+            meta[dst].def_idx = i;
+            meta[dst].type    = type;
+        };
+        auto addUse = [&](VReg vreg) {
+            meta[vreg].last_any_use = max(meta[vreg].last_any_use, i);
+        };
+        auto setBinOp = [&](VReg dst, VReg lhs, VReg rhs, VRegType type) {
+            setDef(dst, type);
+            addUse(lhs);
+            addUse(rhs);
+        };
+        auto addCallArgs = [&](const vector<VReg>& args) {
+            for (int j = 0; j < (int)args.size(); j++) {
                 if (j < (int)phys.intArgs.size())
-                    meta[c->args[j]].call_uses.push_back({i, j});
+                    meta[args[j]].call_uses.push_back({i, j});
                 else
-                    meta[c->args[j]].last_any_use = max(meta[c->args[j]].last_any_use, i);
+                    addUse(args[j]);
             }
-            if (c->dst != -1) {
-                meta[c->dst].def_idx = i;
-                meta[c->dst].type    = c->retType;
-            }
-        } else if (auto* c = get_if<CallPln>(&instr)) {
-            call_indices.push_back(i);
-            for (int j = 0; j < (int)c->args.size(); j++) {
-                if (j < (int)phys.intArgs.size())
-                    meta[c->args[j]].call_uses.push_back({i, j});
-                else
-                    meta[c->args[j]].last_any_use = max(meta[c->args[j]].last_any_use, i);
-            }
-            for (int k = 0; k < (int)c->dsts.size(); k++) {
-                meta[c->dsts[k]].def_idx = i;
-                meta[c->dsts[k]].type    = c->retTypes[k];
-            }
-        } else if (auto* r = get_if<RetPln>(&instr)) {
-            for (int k = 0; k < (int)r->rets.size(); k++) {
-                meta[r->rets[k]].last_any_use =
-                    max(meta[r->rets[k]].last_any_use, i);
-                meta[r->rets[k]].isRetValue = true;
-                meta[r->rets[k]].retIdx     = k;
-            }
-        } else if (auto* cj = get_if<CondJmp>(&instr)) {
-            meta[cj->cond].last_any_use = max(meta[cj->cond].last_any_use, i);
-        } else if (auto* lbl = get_if<Label>(&instr)) {
-            label_idx[lbl->name] = i;
-        } else if (auto* mv = get_if<Mov>(&instr)) {
+        };
+
+        std::visit(overloaded{
+            [&](const LeaLabel& l) { setDef(l.dst, l.type); },
+            [&](const MovImm& m)   { setDef(m.dst, m.type); },
+            [&](const InitVar& v)  { setDef(v.dst, v.type); meta[v.dst].isVar = true; },
+            [&](const Add& a)      { setBinOp(a.dst, a.lhs, a.rhs, a.type); },
+            [&](const Sub& s)      { setBinOp(s.dst, s.lhs, s.rhs, s.type); },
+            [&](const Mul& m)      { setBinOp(m.dst, m.lhs, m.rhs, m.type); },
+            [&](const Div& d)      { divmod_indices.push_back(i); setBinOp(d.dst, d.lhs, d.rhs, d.type); },
+            [&](const Mod& m)      { divmod_indices.push_back(i); setBinOp(m.dst, m.lhs, m.rhs, m.type); },
+            [&](const Neg& n)      { setDef(n.dst, n.type); addUse(n.src); },
+            [&](const Cmp& c)      { setDef(c.dst, VRegType::Int32); addUse(c.lhs); addUse(c.rhs); },
+            [&](const Convert& c)  { setDef(c.dst, c.to); addUse(c.src); },
+            [&](const CallC& c) {
+                call_indices.push_back(i);
+                addCallArgs(c.args);
+                if (c.dst != -1) setDef(c.dst, c.retType);
+            },
+            [&](const CallPln& c) {
+                call_indices.push_back(i);
+                addCallArgs(c.args);
+                for (int k = 0; k < (int)c.dsts.size(); k++)
+                    setDef(c.dsts[k], c.retTypes[k]);
+            },
+            [&](const RetPln& r) {
+                for (VReg vr : r.rets) {
+                    addUse(vr);
+                    meta[vr].isRetValue = true;
+                }
+            },
+            [&](const CondJmp& cj) { addUse(cj.cond); },
+            [&](const Label& lbl)  { label_idx[lbl.name] = i; },
             // Mov copies src into dst (the variable's canonical VReg).
             // dst is always isVar (allocated by Pass B); only src needs tracking here.
-            meta[mv->src].last_any_use = max(meta[mv->src].last_any_use, i);
-        }
+            [&](const Mov& mv)     { addUse(mv.src); },
+            [&](const ExitCode&)   {},
+            [&](const BlockEnter&) {},
+            [&](const BlockLeave&) {},
+            [&](const Jmp&)        {},
+        }, instr);
     }
 
     // Collect loop regions: backward jumps define [loop_start_label_idx, jmp_idx].

--- a/src/codegen/PlnVCodeGen.cpp
+++ b/src/codegen/PlnVCodeGen.cpp
@@ -303,6 +303,20 @@ void PlnVCodeGen::lowerIfStmt(const IfStmt& stmt, VFunc& func)
     func.instrs.push_back(Label{endLabel});
 }
 
+void PlnVCodeGen::lowerWhileStmt(const WhileStmt& stmt, VFunc& func)
+{
+    int    idx        = labelCounter_++;
+    string startLabel = ".Lwhile" + to_string(idx) + "_start";
+    string endLabel   = ".Lwhile" + to_string(idx) + "_end";
+
+    func.instrs.push_back(Label{startLabel});
+    VReg cond = lowerExpr(*stmt.cond, func);
+    func.instrs.push_back(CondJmp{endLabel, cond, true});  // jump to end if cond == 0
+    lowerStmt(*stmt.body, func);
+    func.instrs.push_back(Jmp{startLabel});
+    func.instrs.push_back(Label{endLabel});
+}
+
 void PlnVCodeGen::lowerStmt(const Stmt& stmt, VFunc& func)
 {
     switch (stmt.kind) {
@@ -326,6 +340,9 @@ void PlnVCodeGen::lowerStmt(const Stmt& stmt, VFunc& func)
             return;
         case StmtKind::If:
             lowerIfStmt(static_cast<const IfStmt&>(stmt), func);
+            return;
+        case StmtKind::While:
+            lowerWhileStmt(static_cast<const WhileStmt&>(stmt), func);
             return;
     }
     BOOST_ASSERT(false);

--- a/src/codegen/PlnVCodeGen.cpp
+++ b/src/codegen/PlnVCodeGen.cpp
@@ -172,11 +172,16 @@ void PlnVCodeGen::lowerPlnCallExpr(const PlnCallExpr& expr, VFunc& func)
 void PlnVCodeGen::lowerAssignStmt(const AssignStmt& stmt, VFunc& func)
 {
     VReg src = lowerExpr(*stmt.value, func);
-    // Rebind in the scope where the variable was declared (not necessarily innermost).
+    // Find the variable's canonical VReg and emit a Mov to update it in place.
+    // This keeps the VReg identity stable so that backward references — most
+    // importantly, while-loop condition VInstrs that captured the VReg before the
+    // loop body ran — always see the current value after each iteration.
     for (auto it = varScopes.rbegin(); it != varScopes.rend(); ++it) {
         auto f = it->find(stmt.name);
         if (f != it->end()) {
-            f->second = src;
+            VReg old_vreg = f->second;
+            if (old_vreg != src)
+                func.instrs.push_back(Mov{old_vreg, src, stmt.type});
             return;
         }
     }

--- a/src/codegen/PlnVCodeGen.h
+++ b/src/codegen/PlnVCodeGen.h
@@ -42,6 +42,7 @@ class PlnVCodeGen {
     void lowerTappleDeclStmt(const TappleDeclStmt& stmt, VFunc& func);
     void lowerBlockStmt(const BlockStmt& stmt, VFunc& func);
     void lowerIfStmt(const IfStmt& stmt, VFunc& func);
+    void lowerWhileStmt(const WhileStmt& stmt, VFunc& func);
 
 public:
     VProg generate(const Module& module, bool noEntry = false);

--- a/src/codegen/PlnVProg.h
+++ b/src/codegen/PlnVProg.h
@@ -47,11 +47,12 @@ struct BlockLeave { vector<VReg> expiredVars; };
 struct Label      { string name; };                              // name:
 struct Jmp        { string label; };                             // jmp label
 struct CondJmp    { string label; VReg cond; bool jumpIfZero; }; // testl+je/jne
+struct Mov        { VReg dst; VReg src; VRegType type; };        // dst = src (variable update)
 
 using VInstr = std::variant<LeaLabel, MovImm, InitVar, Add, Sub, Mul, Div, Mod, Neg, Cmp, Convert,
                              CallC, CallPln, RetPln, ExitCode,
                              BlockEnter, BlockLeave,
-                             Label, Jmp, CondJmp>;
+                             Label, Jmp, CondJmp, Mov>;
 
 // -------- Program structure --------
 

--- a/src/codegen/PlnX86CodeGen.cpp
+++ b/src/codegen/PlnX86CodeGen.cpp
@@ -469,6 +469,25 @@ void PlnX86CodeGen::emit(const VProg& prog)
                 }
                 out << "\ttestl " << cond_reg << ", " << cond_reg << "\n";
                 out << (cj->jumpIfZero ? "\tje " : "\tjne ") << cj->label << "\n";
+            } else if (auto* mv = std::get_if<Mov>(&instr)) {
+                // Copy src into dst (variable's canonical stack slot or register).
+                if (!rm.count(mv->dst) || !rm.count(mv->src)) continue;
+                const PhysLoc& dst_loc = rm.at(mv->dst);
+                const PhysLoc& src_loc = rm.at(mv->src);
+                string s = srcOperand(src_loc);
+                string d = srcOperand(dst_loc);
+                if (s == d) continue;  // same location: no-op
+                if (!dst_loc.isStack()) {
+                    string dst_reg = sizedRegName(dst_loc.base, mv->type);
+                    out << "\t" << movInstrForType(mv->type) << " " << s << ", " << dst_reg << "\n";
+                } else if (!src_loc.isStack()) {
+                    out << "\t" << movInstrForType(mv->type) << " " << s << ", " << d << "\n";
+                } else {
+                    // Both on stack: route through scratch %rax.
+                    string scratch = sizedRegName("%rax", mv->type);
+                    out << "\t" << movInstrForType(mv->type) << " " << s << ", " << scratch << "\n";
+                    out << "\t" << movInstrForType(mv->type) << " " << scratch << ", " << d << "\n";
+                }
             }
         }
     }

--- a/src/common/PlnDefs.h
+++ b/src/common/PlnDefs.h
@@ -5,4 +5,4 @@
 
 #pragma once
 
-#define PALAN_VERSION "0.1.10"
+#define PALAN_VERSION "0.1.11"

--- a/src/gen-ast/PlnParser.yy
+++ b/src/gen-ast/PlnParser.yy
@@ -151,7 +151,7 @@ class PlnLexer;
 %type <json>	statement_or_funcdef
 %type <bool>	move_owner_r do_export
 %type <json>	tapple_decl tapple_decl_inner tapple_inner
-%type <json>	if_stmt else_stmt
+%type <json>	if_stmt else_stmt while_loop
 
 %left ARROW DBL_ARROW
 %left OPE_EQ OPE_NE
@@ -288,8 +288,7 @@ statement: import ';'
 	}
 	| while_loop
 	{
-		json temp = {{"stmt-type", "not-impl"}};
-		$$ = move(temp);
+		$$ = move($1);
 	}
 	| if_stmt
 	{
@@ -713,6 +712,10 @@ for_loop: KW_FOR ID ':' expression block
 	;
 
 while_loop: KW_WHILE expression block
+	{
+		$$ = {{"stmt-type", "while"}, {"cond", $2}, {"body", move($3)}};
+		LOC($$, @$);
+	}
 	;
 
 if_stmt: KW_IF expression block else_stmt

--- a/src/semantic-anlyzr/PlnSaMessage.cpp
+++ b/src/semantic-anlyzr/PlnSaMessage.cpp
@@ -70,6 +70,9 @@ string PlnSaMessage::getMessage(PlnSaMessageCode msg_code, string arg1, string a
 		case E_VoidBareReturn:
 			return "Void function requires bare 'return;' statement.";
 
+		case E_VoidCallUsedAsValue:
+			return "Void function call cannot be used as a value.";
+
 		case E_TupleUndefinedFunction:
 			BOOST_ASSERT(arg1 != "\x01");
 			return "Undefined function '" + arg1 + "'.";

--- a/src/semantic-anlyzr/PlnSaMessage.h
+++ b/src/semantic-anlyzr/PlnSaMessage.h
@@ -23,6 +23,7 @@ enum PlnSaMessageCode {
 	E_MultiRetBareReturn,
 	E_SingleRetOneExpr,
 	E_VoidBareReturn,
+	E_VoidCallUsedAsValue,
 	E_TupleUndefinedFunction,	// arg1: function name
 	E_TupleNeedsMultiRet,		// arg1: function name
 	E_TupleVarCountMismatch,	// arg1: function name

--- a/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
+++ b/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
@@ -154,6 +154,7 @@ json PlnSemanticAnalyzer::sa_statements(const json& stmts)
 		else if (t == "return")      result.push_back(sa_return_stmt(stmt));
 		else if (t == "tapple-decl") result.push_back(sa_tapple_decl(stmt));
 		else if (t == "if")       result.push_back(sa_if_stmt(stmt));
+		else if (t == "while")    result.push_back(sa_while_stmt(stmt));
 		else if (t == "not-impl")    result.push_back(stmt);
 		else if (t == "func-def") {
 			cerr << locPrefix(stmt) << PlnSaMessage::getMessage(E_InternalError, "1") << endl;
@@ -412,6 +413,19 @@ json PlnSemanticAnalyzer::sa_if_stmt(const json& stmt)
 		else
 			result["else"] = sa_block(els);
 	}
+	if (stmt.contains("loc"))
+		result["loc"] = stmt["loc"];
+	return result;
+}
+
+json PlnSemanticAnalyzer::sa_while_stmt(const json& stmt)
+{
+	json result;
+	result["stmt-type"] = "while";
+	result["cond"] = sa_expression(stmt["cond"]);
+	enterScope();
+	result["body"] = sa_statements(stmt["body"]);
+	leaveScope();
 	if (stmt.contains("loc"))
 		result["loc"] = stmt["loc"];
 	return result;

--- a/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
+++ b/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
@@ -345,8 +345,12 @@ json PlnSemanticAnalyzer::sa_var_decl(const json& stmt)
 			// should be an error, not silently read uninitialized z).
 			const PlnType* toType = registry_.fromJson(var["var-type"]);
 			json init = sa_expression(var["init"], toType);
+			if (!init.contains("value-type")) {
+				cerr << locPrefix(stmt) << PlnSaMessage::getMessage(E_VoidCallUsedAsValue) << endl;
+				exit(1);
+			}
 			const json& var_type = var["var-type"];
-			if (init.contains("value-type") && init["value-type"] != var_type) {
+			if (init["value-type"] != var_type) {
 				const PlnType* fromType = registry_.fromJson(init["value-type"]);
 				TypeCompat compat = typeCompat(fromType, toType, registry_);
 				if (compat == TypeCompat::ImplicitWiden) {
@@ -489,12 +493,14 @@ json PlnSemanticAnalyzer::sa_assign_stmt(const json& stmt)
 	}
 	const PlnType* toType = registry_.fromJson(*varType);
 	json value = sa_expression(stmt["value"], toType);
-	if (value.contains("value-type")) {
-		const PlnType* fromType = registry_.fromJson(value["value-type"]);
-		TypeCompat compat = typeCompat(fromType, toType, registry_);
-		if (compat == TypeCompat::ImplicitWiden || compat == TypeCompat::ExplicitCast)
-			value = wrapConvert(value, registry_.toJson(toType));
+	if (!value.contains("value-type")) {
+		cerr << locPrefix(stmt) << PlnSaMessage::getMessage(E_VoidCallUsedAsValue) << endl;
+		exit(1);
 	}
+	const PlnType* fromType = registry_.fromJson(value["value-type"]);
+	TypeCompat compat = typeCompat(fromType, toType, registry_);
+	if (compat == TypeCompat::ImplicitWiden || compat == TypeCompat::ExplicitCast)
+		value = wrapConvert(value, registry_.toJson(toType));
 	return {{"stmt-type", "assign"}, {"name", name}, {"value", value}};
 }
 

--- a/src/semantic-anlyzr/PlnSemanticAnalyzer.h
+++ b/src/semantic-anlyzr/PlnSemanticAnalyzer.h
@@ -55,6 +55,7 @@ class PlnSemanticAnalyzer {
 	json sa_tapple_decl(const json& stmt);
 	json sa_block(const json& stmt);
 	json sa_if_stmt(const json& stmt);
+	json sa_while_stmt(const json& stmt);
 
 public:
 	PlnSemanticAnalyzer(string base_path, string ast_filename, string c2ast_path);

--- a/test/build-mgr-tester/basicTests.cpp
+++ b/test/build-mgr-tester/basicTests.cpp
@@ -76,6 +76,23 @@ TEST(build_mgr, divmod_rdx_conflict) {
 	ASSERT_EQ(output, "17\n");
 }
 
+TEST(build_mgr, param_loop_call_arg) {
+	cleanTestEnv();
+	// Parameter n is used only as call arg inside loop (not Cmp operand).
+	// Covers RegAlloc lines 172-173: call_uses loop-region check for params.
+	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/014_param_loop_call_arg.pa");
+	ASSERT_EQ(output, "42\n42\n42\n");
+}
+
+TEST(build_mgr, rdx_divmod_conflict) {
+	cleanTestEnv();
+	// r (CallPln result, desired %rdx) spans a Div before use as 3rd printf arg.
+	// Covers RegAlloc lines 265-267: divmod conflict detection forces callee-saved.
+	// Without the fix, idivq would clobber %rdx (remainder=1), giving "3 1" instead of "3 10".
+	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/015_rdx_divmod_conflict.pa");
+	ASSERT_EQ(output, "3 10\n");
+}
+
 TEST(build_mgr, collatz) {
 	cleanTestEnv();
 	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/012_collatz.pa");

--- a/test/build-mgr-tester/basicTests.cpp
+++ b/test/build-mgr-tester/basicTests.cpp
@@ -76,6 +76,18 @@ TEST(build_mgr, divmod_rdx_conflict) {
 	ASSERT_EQ(output, "17\n");
 }
 
+TEST(build_mgr, collatz) {
+	cleanTestEnv();
+	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/012_collatz.pa");
+	ASSERT_EQ(output, "collatz(27) = 111\ncollatz(871) = 178\n");
+}
+
+TEST(build_mgr, fizzbuzz) {
+	cleanTestEnv();
+	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/013_fizzbuzz.pa");
+	ASSERT_EQ(output, "1\n2\nFizz\n4\nBuzz\nFizz\n7\n8\nFizz\nBuzz\n11\nFizz\n13\n14\nFizzBuzz\n16\n17\nFizz\n19\nBuzz\n");
+}
+
 TEST(build_mgr, clean) {
 	cleanTestEnv();
 

--- a/test/codegen-tester/basicTests.cpp
+++ b/test/codegen-tester/basicTests.cpp
@@ -459,3 +459,23 @@ TEST(codegen, div_rhs_in_rax) {
     ASSERT_NE(asm_text.find("movq %rax, %r10"), string::npos);
     ASSERT_NE(asm_text.find("idivq %r10"),      string::npos);
 }
+
+TEST(codegen, while_loop) {
+    cleanTestEnv();
+    string sa   = "../test/testdata/codegen/027_while_loop.sa.json";
+    string asmf = "out/027_while_loop.s";
+
+    string err = run_codegen(sa, asmf);
+    ASSERT_EQ(err, "");
+
+    string asm_text = readFile(asmf);
+    // while loop: start/end labels
+    ASSERT_NE(asm_text.find(".Lwhile0_start:"),      string::npos);
+    ASSERT_NE(asm_text.find(".Lwhile0_end:"),        string::npos);
+    // condition test and conditional jump to end
+    ASSERT_NE(asm_text.find("testl"),                string::npos);
+    ASSERT_NE(asm_text.find("je "),                  string::npos);
+    // unconditional back-jump to start
+    ASSERT_NE(asm_text.find("\tjmp .Lwhile0_start"), string::npos);
+    ASSERT_NE(asm_text.find("call printf"),          string::npos);
+}

--- a/test/codegen-tester/basicTests.cpp
+++ b/test/codegen-tester/basicTests.cpp
@@ -479,3 +479,25 @@ TEST(codegen, while_loop) {
     ASSERT_NE(asm_text.find("\tjmp .Lwhile0_start"), string::npos);
     ASSERT_NE(asm_text.find("call printf"),          string::npos);
 }
+
+TEST(codegen, void_func) {
+    cleanTestEnv();
+    string sa   = "../test/testdata/codegen/028_void_func.sa.json";
+    string asmf = "out/028_void_func.s";
+
+    string err = run_codegen(sa, asmf);
+    ASSERT_EQ(err, "");
+
+    string asm_text = readFile(asmf);
+    // void function: label present, leave+ret emitted
+    ASSERT_NE(asm_text.find("greet:"),   string::npos);
+    ASSERT_NE(asm_text.find("leave"),    string::npos);
+    ASSERT_NE(asm_text.find("\tret"),    string::npos);
+    // caller: call instruction present, but no movq %rax after it
+    ASSERT_NE(asm_text.find("call greet"), string::npos);
+    // no return-value move: greet returns void so %rax is not copied anywhere
+    size_t call_pos = asm_text.find("call greet");
+    ASSERT_NE(call_pos, string::npos);
+    string after_call = asm_text.substr(call_pos + string("call greet").size(), 30);
+    ASSERT_EQ(after_call.find("movq %rax"), string::npos);
+}

--- a/test/codegen-tester/basicTests.cpp
+++ b/test/codegen-tester/basicTests.cpp
@@ -480,6 +480,19 @@ TEST(codegen, while_loop) {
     ASSERT_NE(asm_text.find("call printf"),          string::npos);
 }
 
+TEST(codegen, int8_var) {
+    cleanTestEnv();
+    string sa   = "../test/testdata/codegen/029_int8_var.sa.json";
+    string asmf = "out/029_int8_var.s";
+
+    string err = run_codegen(sa, asmf);
+    ASSERT_EQ(err, "");
+
+    string asm_text = readFile(asmf);
+    // Int8 variable → 1-byte stack slot: movb instruction and -1(%rbp) offset
+    ASSERT_NE(asm_text.find("movb $5, -1(%rbp)"), string::npos);
+}
+
 TEST(codegen, void_func) {
     cleanTestEnv();
     string sa   = "../test/testdata/codegen/028_void_func.sa.json";

--- a/test/codegen-unit-tester/basicTests.cpp
+++ b/test/codegen-unit-tester/basicTests.cpp
@@ -154,20 +154,21 @@ TEST(regalloc, convert_src_uses_callee_saved) {
 // -------- Efficiency cases --------
 
 // InitVar with a direct call use bypasses isVar→stack rule → gets arg register (no stack needed)
-TEST(regalloc, initvar_direct_call_use_gets_arg_register) {
+// InitVar (isVar) always goes to stack regardless of call uses — callers load from stack
+TEST(regalloc, initvar_direct_call_use_always_stack) {
     VFunc func;
     func.instrs.push_back(InitVar{0, VRegType::Int64, 10});
     func.instrs.push_back(CallC{"foo", {0}});
 
     auto r = allocateRegisters(func, testPhys);
 
-    ASSERT_FALSE(r.regMap.at(0).isStack());
-    EXPECT_EQ(r.regMap.at(0).base, "%rdi");
-    EXPECT_EQ(r.frameSize, 0);
+    ASSERT_TRUE(r.regMap.at(0).isStack());
+    // Stack layout: 8-byte slot for r0 → frameSize = alignUp(8,16) = 16
+    EXPECT_EQ(r.frameSize, 16);
 }
 
-// InitVar with intervening call → takes callee-saved path (not forced to stack by isVar)
-TEST(regalloc, initvar_with_intervening_call_gets_callee_saved) {
+// InitVar with intervening call → still on stack (isVar always stack-allocated)
+TEST(regalloc, initvar_with_intervening_call_always_stack) {
     VFunc func;
     func.instrs.push_back(InitVar{0, VRegType::Int64, 10});  // r0 def at 0
     func.instrs.push_back(CallC{"foo", {}});                  // idx 1: intervening
@@ -175,9 +176,7 @@ TEST(regalloc, initvar_with_intervening_call_gets_callee_saved) {
 
     auto r = allocateRegisters(func, testPhys);
 
-    ASSERT_FALSE(r.regMap.at(0).isStack());
-    EXPECT_EQ(r.regMap.at(0).base, "%rbx");
-    // k=1 callee-saved used → save area = 8 bytes → frameSize = alignUp(8,16) = 16
+    ASSERT_TRUE(r.regMap.at(0).isStack());
     EXPECT_EQ(r.frameSize, 16);
 }
 

--- a/test/gen-ast-tester/basicTests.cpp
+++ b/test/gen-ast-tester/basicTests.cpp
@@ -321,6 +321,29 @@ TEST(gen_ast, if_stmt) {
 	ASSERT_TRUE(found_sign);
 }
 
+TEST(gen_ast, while_loop) {
+	cleanTestEnv();
+	string output = execTestCommand("bin/palan-gen-ast ../test/testdata/gen-ast/009_while_loop.pa");
+	ASSERT_TRUE(checkerr(output));
+	json jout = json::parse(output);
+
+	bool found_countdown = false;
+	for (auto& f : jout["ast"]["functions"]) {
+		if (f["name"] != "countDown") continue;
+		found_countdown = true;
+		const auto& body = f["block"]["body"];
+		ASSERT_GE(body.size(), 1u);
+		const auto& wh = body[0];
+		ASSERT_EQ(wh["stmt-type"], "while");
+		ASSERT_EQ(wh["cond"]["expr-type"], "cmp");
+		ASSERT_EQ(wh["cond"]["op"], ">");
+		ASSERT_TRUE(wh.contains("body"));
+		ASSERT_EQ(wh["body"].size(), 1u);
+		ASSERT_EQ(wh["body"][0]["stmt-type"], "assign");
+	}
+	ASSERT_TRUE(found_countdown);
+}
+
 TEST(gen_ast, cli_tests) {
 	cleanTestEnv();
 	string output = execTestCommand("bin/palan-gen-ast -h");

--- a/test/sa-tester/basicTests.cpp
+++ b/test/sa-tester/basicTests.cpp
@@ -538,3 +538,24 @@ TEST(sa, unary_minus) {
 	}
 	ASSERT_TRUE(found_neg);
 }
+
+TEST(sa, while_stmt) {
+	cleanTestEnv();
+	json jout = run_sa("../test/testdata/sa/039_while_loop.pa");
+
+	ASSERT_TRUE(jout.is_object());
+	bool found_while = false;
+	for (auto& stmt : jout["statements"]) {
+		if (stmt["stmt-type"] != "while") continue;
+		found_while = true;
+		// cond is a cmp expression with value-type int32
+		ASSERT_EQ(stmt["cond"]["expr-type"], "cmp");
+		ASSERT_EQ(stmt["cond"]["value-type"]["type-name"], "int32");
+		ASSERT_EQ(stmt["cond"]["op"], "<");
+		// body is a raw array containing an assign statement
+		ASSERT_TRUE(stmt.contains("body"));
+		ASSERT_EQ(stmt["body"].size(), 1u);
+		ASSERT_EQ(stmt["body"][0]["stmt-type"], "assign");
+	}
+	ASSERT_TRUE(found_while);
+}

--- a/test/sa-tester/basicTests.cpp
+++ b/test/sa-tester/basicTests.cpp
@@ -559,3 +559,31 @@ TEST(sa, while_stmt) {
 	}
 	ASSERT_TRUE(found_while);
 }
+
+TEST(sa, void_func) {
+	cleanTestEnv();
+	json jout = run_sa("../test/testdata/sa/040_void_func.pa");
+
+	ASSERT_TRUE(jout.is_object());
+
+	// greet function: no ret-type, body has bare return
+	ASSERT_EQ(jout["functions"].size(), 1u);
+	const json& greet = jout["functions"][0];
+	ASSERT_EQ(greet["name"], "greet");
+	ASSERT_FALSE(greet.contains("ret-type"));
+	ASSERT_FALSE(greet.contains("rets"));
+	ASSERT_EQ(greet["body"][0]["stmt-type"], "return");
+	ASSERT_FALSE(greet["body"][0].contains("values"));
+
+	// greet() called as expr stmt: no value-type on the call
+	bool found_call = false;
+	for (auto& stmt : jout["statements"]) {
+		if (stmt["stmt-type"] != "expr") continue;
+		auto& body = stmt["body"];
+		if (body["expr-type"] != "call" || body["name"] != "greet") continue;
+		ASSERT_EQ(body["func-type"], "palan");
+		ASSERT_FALSE(body.contains("value-type"));
+		found_call = true;
+	}
+	ASSERT_TRUE(found_call);
+}

--- a/test/sa-tester/errorTests.cpp
+++ b/test/sa-tester/errorTests.cpp
@@ -176,3 +176,12 @@ TEST(sa_error, import_file_not_found) {
 	string sa = execTestCommand("bin/palan-sa " + ast_out + " -o out/test.sa.json");
 	ASSERT_NE(sa.find("Could not open import file"), string::npos);
 }
+
+TEST(sa_error, void_call_as_expr) {
+	cleanTestEnv();
+	string ast_out = "out/test.ast.json";
+	ASSERT_EQ(execTestCommand(
+		"bin/palan-gen-ast ../test/testdata/sa/error_040_void_call_as_expr.pa -o " + ast_out), "");
+	string sa = execTestCommand("bin/palan-sa " + ast_out + " -o out/test.sa.json");
+	ASSERT_NE(sa.find("Void function call cannot be used as a value"), string::npos);
+}

--- a/test/testdata/build-mgr/011_void_func.pa
+++ b/test/testdata/build-mgr/011_void_func.pa
@@ -1,0 +1,11 @@
+cinclude <stdio.h>;
+
+func print_range(int64 n) {
+    int64 i = 1;
+    while i <= n {
+        printf("%ld\n", i);
+        i + 1 -> i;
+    }
+}
+
+print_range(3);

--- a/test/testdata/build-mgr/012_collatz.pa
+++ b/test/testdata/build-mgr/012_collatz.pa
@@ -1,0 +1,14 @@
+cinclude <stdio.h>;
+
+func collatz_steps(int64 n) -> int64 {
+    int64 steps = 0;
+    while n != 1 {
+        if n % 2 == 0 { n / 2 -> n; }
+        else { n * 3 + 1 -> n; }
+        steps + 1 -> steps;
+    }
+    return steps;
+}
+
+printf("collatz(27) = %ld\n", collatz_steps(27));
+printf("collatz(871) = %ld\n", collatz_steps(871));

--- a/test/testdata/build-mgr/013_fizzbuzz.pa
+++ b/test/testdata/build-mgr/013_fizzbuzz.pa
@@ -1,0 +1,14 @@
+cinclude <stdio.h>;
+
+func fizzbuzz(int64 n) {
+    int64 i = 1;
+    while i <= n {
+        if i % 15 == 0 { printf("FizzBuzz\n"); }
+        else if i % 3 == 0 { printf("Fizz\n"); }
+        else if i % 5 == 0 { printf("Buzz\n"); }
+        else { printf("%ld\n", i); }
+        i + 1 -> i;
+    }
+}
+
+fizzbuzz(20);

--- a/test/testdata/build-mgr/014_param_loop_call_arg.pa
+++ b/test/testdata/build-mgr/014_param_loop_call_arg.pa
@@ -1,0 +1,14 @@
+cinclude <stdio.h>;
+
+// Parameter n is used only as a call argument inside the while loop (not as Cmp operand).
+// This triggers the call_uses loop-region check in RegAlloc (lines 172-173):
+// last_any_use=-1 so the first branch misses; the call_uses loop detects n is live in loop.
+func print_n_times(int64 n) {
+    int64 i = 0;
+    while i < 3 {
+        printf("%ld\n", n);
+        i + 1 -> i;
+    }
+}
+
+print_n_times(42);

--- a/test/testdata/build-mgr/015_rdx_divmod_conflict.pa
+++ b/test/testdata/build-mgr/015_rdx_divmod_conflict.pa
@@ -1,0 +1,11 @@
+cinclude <stdio.h>;
+
+// r is the result of get_val() (non-isVar VReg, desired for %rdx as 3rd arg of printf).
+// A Div instruction appears between r's definition and its use as 3rd printf arg.
+// Without the divmod conflict check (RegAlloc lines 265-267), idivq would clobber
+// %rdx with the remainder (10%3=1), producing wrong output "3 1" instead of "3 10".
+func get_val() -> int64 { return 10; }
+
+int64 r = get_val();
+int64 q = r / 3;
+printf("%ld %ld\n", q, r);

--- a/test/testdata/codegen/027_while_loop.sa.json
+++ b/test/testdata/codegen/027_while_loop.sa.json
@@ -1,0 +1,50 @@
+{
+  "original": "/test/while_loop.pa",
+  "str-literals": [
+    { "label": ".str0", "value": "%lld\n" }
+  ],
+  "statements": [
+    {
+      "stmt-type": "var-decl",
+      "vars": [
+        {
+          "name": "i",
+          "var-type": { "type-kind": "prim", "type-name": "int64" },
+          "init": { "expr-type": "lit-int", "value": "0", "value-type": { "type-kind": "prim", "type-name": "int64" } }
+        }
+      ]
+    },
+    {
+      "stmt-type": "while",
+      "cond": {
+        "expr-type": "cmp",
+        "op": "<",
+        "value-type": { "type-kind": "prim", "type-name": "int32" },
+        "left":  { "expr-type": "id", "name": "i", "var-type": { "type-kind": "prim", "type-name": "int64" }, "value-type": { "type-kind": "prim", "type-name": "int64" } },
+        "right": { "expr-type": "lit-int", "value": "3", "value-type": { "type-kind": "prim", "type-name": "int64" } }
+      },
+      "body": [
+        {
+          "stmt-type": "assign",
+          "name": "i",
+          "value": {
+            "expr-type": "add",
+            "value-type": { "type-kind": "prim", "type-name": "int64" },
+            "left":  { "expr-type": "id", "name": "i", "var-type": { "type-kind": "prim", "type-name": "int64" }, "value-type": { "type-kind": "prim", "type-name": "int64" } },
+            "right": { "expr-type": "lit-int", "value": "1", "value-type": { "type-kind": "prim", "type-name": "int64" } }
+          }
+        }
+      ]
+    },
+    {
+      "stmt-type": "expr",
+      "body": {
+        "expr-type": "call", "func-type": "c", "name": "printf",
+        "args": [
+          { "expr-type": "lit-str", "label": ".str0", "value-type": { "type-kind": "pntr", "base-type": { "type-kind": "prim", "type-name": "uint8" } } },
+          { "expr-type": "id", "name": "i", "var-type": { "type-kind": "prim", "type-name": "int64" }, "value-type": { "type-kind": "prim", "type-name": "int64" } }
+        ]
+      }
+    }
+  ]
+}

--- a/test/testdata/codegen/028_void_func.sa.json
+++ b/test/testdata/codegen/028_void_func.sa.json
@@ -1,0 +1,26 @@
+{
+  "original": "/test/void_func.pa",
+  "str-literals": [],
+  "functions": [
+    {
+      "name": "greet",
+      "parameters": [
+        { "name": "n", "var-type": { "type-kind": "prim", "type-name": "int64" } }
+      ],
+      "body": [
+        { "stmt-type": "return" }
+      ]
+    }
+  ],
+  "statements": [
+    {
+      "stmt-type": "expr",
+      "body": {
+        "expr-type": "call", "func-type": "palan", "name": "greet",
+        "args": [
+          { "expr-type": "lit-int", "value": "1", "value-type": { "type-kind": "prim", "type-name": "int64" } }
+        ]
+      }
+    }
+  ]
+}

--- a/test/testdata/codegen/029_int8_var.sa.json
+++ b/test/testdata/codegen/029_int8_var.sa.json
@@ -1,0 +1,20 @@
+{
+  "original": "/test/int8_var.pa",
+  "str-literals": [],
+  "statements": [
+    {
+      "stmt-type": "var-decl",
+      "vars": [
+        {
+          "name": "x",
+          "var-type": { "type-kind": "prim", "type-name": "int8" },
+          "init": {
+            "expr-type": "lit-int",
+            "value": "5",
+            "value-type": { "type-kind": "prim", "type-name": "int8" }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/testdata/gen-ast/009_while_loop.pa
+++ b/test/testdata/gen-ast/009_while_loop.pa
@@ -1,0 +1,6 @@
+func countDown(int64 n) -> int64 {
+    while n > 0 {
+        n - 1 -> n;
+    }
+    return n;
+}

--- a/test/testdata/sa/039_while_loop.pa
+++ b/test/testdata/sa/039_while_loop.pa
@@ -1,0 +1,6 @@
+cinclude <stdio.h>;
+int64 i = 0;
+while i < 3 {
+    i + 1 -> i;
+}
+printf("%lld\n", i);

--- a/test/testdata/sa/040_void_func.pa
+++ b/test/testdata/sa/040_void_func.pa
@@ -1,0 +1,4 @@
+func greet(int64 n) {
+    return;
+}
+greet(1);

--- a/test/testdata/sa/error_040_void_call_as_expr.pa
+++ b/test/testdata/sa/error_040_void_call_as_expr.pa
@@ -1,0 +1,3 @@
+func greet() {
+}
+int64 x = greet();


### PR DESCRIPTION
## Summary

- Implement `while` loops across all compiler stages (gen-ast, SA, codegen)
- Implement void functions (no return value) across all compiler stages
- Fix `PlnRegAlloc`: function parameters used inside while loops containing calls were not marked as `crosses_call`, causing caller-saved registers to be clobbered on each iteration (infinite loop bug)
- Refactor `PlnRegAlloc` metadata scan: replace 90-line if-else chain with `std::visit` + `overloaded` so new `VInstr` types cause compile errors instead of silent no-ops
- Add end-to-end tests: Collatz sequence and FizzBuzz
- Bump version to 0.1.11, add §14 While Loops to PalanReference

## Test plan

- [ ] `make` passes all 175 tests (34 c2ast + 18 gen-ast + 43 sa + 33 codegen + 13 typecompat + 16 regalloc + 18 build-mgr)
- [ ] `build/bin/palan -o /tmp/out test/testdata/build-mgr/012_collatz.pa && /tmp/out` → `collatz(27) = 111` / `collatz(871) = 178`
- [ ] `build/bin/palan -o /tmp/out test/testdata/build-mgr/013_fizzbuzz.pa && /tmp/out` → 1〜20 FizzBuzz
- [ ] `build/bin/palan --version` → `palan 0.1.11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)