### PR TITLE
feat: v0.1.24 — struct array variables ([n]$T / [n]T / [n]@T / [n]@!T)

### DIFF
--- a/doc/PalanReference.md
+++ b/doc/PalanReference.md
@@ -801,10 +801,53 @@ rejects calls where the argument's inner dimension is variable or does not match
 **Memory management:** A single `malloc` is called at declaration and a single `free` is
 inserted at scope exit. No helper functions are generated.
 
+### Struct Arrays
+
+Palan supports four forms of struct array declarations. All are heap-allocated and automatically freed at scope exit.
+
+| Form | Memory | Element type |
+|---|---|---|
+| `[n]$T pts` | `malloc(n * T.totalSize)` / `free(pts)` | contiguous inline elements |
+| `[n]T pts` | `__pln_alloc_arr_T(n)` / `__pln_free_arr_T(pts, n)` | owned pointers, each element allocated separately |
+| `[n]@T pts` | `malloc(n * 8)`, null-initialized / `free(pts)` | non-owning read-only pointers |
+| `[n]@!T pts` | `malloc(n * 8)`, null-initialized / `free(pts)` | non-owning mutable pointers |
+
+`pts[i]` yields a `T` pointer for all four forms. Fields are accessed with `pts[i].field`.
+
+```palan
+cinclude <stdio.h>;
+type Point { int64 x; int64 y; };
+
+// [n]$T — contiguous inline struct array
+[3]$Point pts;
+10 -> pts[0].x;  20 -> pts[0].y;
+printf("%ld %ld\n", pts[0].x, pts[0].y);  // 10 20
+
+// [n]T — owned pointer array (each element separately allocated)
+[2]Point pts2;
+5 -> pts2[0].x;
+printf("%ld\n", pts2[0].x);  // 5
+
+// [n]@T / [n]@!T — non-owning pointer arrays
+Point p;
+99 -> p.x;
+[4]@Point rpts;    // read-only slots
+p -> rpts[0];
+printf("%ld\n", rpts[0].x);   // 99
+
+[4]@!Point wpts;   // writable slots
+p -> wpts[0];
+42 -> wpts[0].x;
+printf("%ld\n", p.x);         // 42 (write-through via pointer)
+```
+
+**Restriction:** `[n]$T` requires that `T` has no owned sub-struct fields. Use `[n]T` instead when `T` contains owned pointer fields.
+
 ### Limitations (current version)
 
 - Top-level (global) array variables are not freed at scope exit (the OS reclaims memory at process exit).
 - Boundary checking is not performed.
+- `[n]$T` is not supported when `T` has owned sub-struct fields.
 
 ## 19. Struct Types
 

--- a/doc/SASpec.md
+++ b/doc/SASpec.md
@@ -295,6 +295,20 @@ SA-only expression kinds (added to AST nodes):
   }
   ```
 
+  **Struct array element access:** When the array element type is `struct(T)`, `arr-index` yields a
+  pointer to the element rather than the element value. The `value-type` and `elem-size` differ by
+  array form:
+
+  | Declaration | value-type | elem-size |
+  |---|---|---|
+  | `[n]$T pts` (contiguous) | `pntr(struct(T))` | `T.totalSize` (e.g. 16 for a two-field int64 struct) |
+  | `[n]T pts` (owned pointers) | `pntr(struct(T))` | `8` (pointer size) |
+  | `[n]@T pts` (read-only) | `pntr(struct(T))` | `8` (pointer size) |
+  | `[n]@!T pts` (mutable) | `pntr(struct(T))` | `8` (pointer size) |
+
+  The returned `pntr(struct(T))` is used as the base for subsequent field access (`pts[i].field`)
+  via `resolveObjectChain`.
+
 Additional fields per expression kind:
 
 - lit-str expression: value replaced by label (assembly label string, e.g. ".str0")

--- a/src/build-mgr/main.cpp
+++ b/src/build-mgr/main.cpp
@@ -271,7 +271,7 @@ int main(int argc, char* argv[])
 					    << "    int64 i = 0;\n"
 					    << "    while i < n {\n"
 					    << "        " << struct_name << " p;\n"
-					    << "        p -> outer[i];\n"
+					    << "        p ->> outer[i];\n"
 					    << "        i + 1 -> i;\n"
 					    << "    }\n"
 					    << "    return outer;\n"

--- a/src/build-mgr/main.cpp
+++ b/src/build-mgr/main.cpp
@@ -173,6 +173,7 @@ int main(int argc, char* argv[])
 		set<string> seen_shapes;
 		vector<json> arr_shapes;
 		vector<json> struct_shapes;
+		vector<json> arr_struct_shapes;
 		for (auto& ast_file : ast_files) {
 			string base = ast_file.substr(0, ast_file.size() - 9);
 			ifstream f(base + ".sa.json");
@@ -187,12 +188,14 @@ int main(int argc, char* argv[])
 				if (!seen_shapes.insert(key).second) continue;
 				if (shape.value("shape-kind", "") == "struct")
 					struct_shapes.push_back(shape);
+				else if (shape.value("shape-kind", "") == "arr-struct")
+					arr_struct_shapes.push_back(shape);
 				else
 					arr_shapes.push_back(shape);
 			}
 		}
 
-		if (!arr_shapes.empty() || !struct_shapes.empty()) {
+		if (!arr_shapes.empty() || !struct_shapes.empty() || !arr_struct_shapes.empty()) {
 			string workdir = fs::path(ast_files[0]).parent_path().string();
 			string alloc_pa  = workdir + "/__allocators.pa";
 			string alloc_ast = alloc_pa + ".ast.json";
@@ -245,6 +248,42 @@ int main(int argc, char* argv[])
 						out << "    __pln_free_" << sname << "(p." << oname << ");\n";
 					}
 					out << "    free(p);\n"
+					    << "    return;\n"
+					    << "}\n";
+				}
+
+				// Owned struct array allocator/free functions
+				for (auto& shape : arr_struct_shapes) {
+					string struct_name = shape["struct-name"];
+					string shape_key   = shape["shape-key"];
+
+					bool has_owned = false;
+					for (auto& ss : struct_shapes)
+						if (ss.value("shape-name","") == struct_name && !ss["owned-fields"].empty())
+							{ has_owned = true; break; }
+					string elem_free = has_owned
+						? "__pln_free_" + struct_name + "(pts[i]);"
+						: "free(pts[i]);";
+
+					out << "\nexport func __pln_alloc_" << shape_key
+					    << "(int64 n) -> []@!" << struct_name << " {\n"
+					    << "    [n]@!" << struct_name << " outer;\n"
+					    << "    int64 i = 0;\n"
+					    << "    while i < n {\n"
+					    << "        " << struct_name << " p;\n"
+					    << "        p -> outer[i];\n"
+					    << "        i + 1 -> i;\n"
+					    << "    }\n"
+					    << "    return outer;\n"
+					    << "}\n"
+					    << "export func __pln_free_" << shape_key
+					    << "([]@!" << struct_name << " pts, int64 n) {\n"
+					    << "    int64 i = 0;\n"
+					    << "    while i < n {\n"
+					    << "        " << elem_free << "\n"
+					    << "        i + 1 -> i;\n"
+					    << "    }\n"
+					    << "    free(pts);\n"
 					    << "    return;\n"
 					    << "}\n";
 				}

--- a/src/common/PlnDefs.h
+++ b/src/common/PlnDefs.h
@@ -5,4 +5,4 @@
 
 #pragma once
 
-#define PALAN_VERSION "0.1.23"
+#define PALAN_VERSION "0.1.24"

--- a/src/gen-ast/PlnParser.yy
+++ b/src/gen-ast/PlnParser.yy
@@ -542,6 +542,11 @@ var_declaration: type_expr move_owner_r ID
 					&& ibt.contains("size-expr") && ibt["size-expr"].is_null();
 			}
 		}
+		bool is_at_struct_arr = tk == "arr"
+			&& $1.value("specifier","") == "raw"
+			&& !$1["size-expr"].is_null()
+			&& $1["base-type"].value("type-kind","") == "pntr"
+			&& $1["base-type"]["base-type"].value("type-kind","") == "prim";
 		bool is_multidim_arr = tk == "arr"
 			&& $1.value("specifier","") == "raw"
 			&& !$1["size-expr"].is_null()
@@ -557,7 +562,7 @@ var_declaration: type_expr move_owner_r ID
 			&& $1["base-type"].value("specifier","") == "raw"
 			&& !$1["base-type"]["size-expr"].is_null()
 			&& $1["base-type"]["base-type"].value("type-kind","") == "prim";
-		if (!$2 && (tk == "prim" || is_valid_arr || is_unsized_arr || is_pntr_arr || is_multidim_arr || is_embed_arr))
+		if (!$2 && (tk == "prim" || is_valid_arr || is_unsized_arr || is_pntr_arr || is_at_struct_arr || is_multidim_arr || is_embed_arr))
 			$$ = {{"name", $3}, {"var-type", move($1)}};
 		else
 			$$ = {{"not-impl", true}};

--- a/src/semantic-anlyzr/PlnSaDecl.cpp
+++ b/src/semantic-anlyzr/PlnSaDecl.cpp
@@ -107,8 +107,12 @@ json PlnSemanticAnalyzer::sa_var_decl(const json& stmt)
 				&& !vtype["size-expr"].is_null()
 				&& vtype.value("embedded", false))
 			return sa_embed_arr_var_decl(stmt);
-		if (tk == "arr" && vtype.value("specifier", "") == "raw" && !vtype["size-expr"].is_null())
+		if (tk == "arr" && vtype.value("specifier", "") == "raw" && !vtype["size-expr"].is_null()) {
+			const json& base = vtype["base-type"];
+			if (base.value("type-kind","") == "prim" && structDefs_.count(base.value("type-name","")))
+				return sa_owned_struct_arr_var_decl(stmt);
 			return sa_arr_var_decl(stmt);
+		}
 		if (tk == "prim") {
 			string tname = vtype.value("type-name", "");
 			if (structDefs_.count(tname))
@@ -513,5 +517,90 @@ json PlnSemanticAnalyzer::sa_struct_var_decl(const json& stmt)
 	}
 	result.push_back(sa_stmt);
 	// LCOV_EXCL_EXCEPTION_BR_STOP
+	return result;
+} // LCOV_EXCL_EXCEPTION_BR_LINE
+
+json PlnSemanticAnalyzer::sa_owned_struct_arr_var_decl(const json& stmt)
+{
+	// [n]T (T = struct): owned pointer array.
+	// __pln_alloc_arr_T(n) on declaration, __pln_free_arr_T(pts, n) at scope exit.
+	const json& vtype = stmt["vars"][0]["var-type"];
+	const json& base_type = vtype["base-type"];
+	string struct_name = base_type["type-name"].get<string>();
+
+	string shape_key = "arr_" + struct_name;
+	bool found = false;
+	for (auto& s : sa["alloc-shapes"])
+		if (s.value("shape-key","") == shape_key) { found = true; break; }
+	if (!found) {
+		// struct shape must be present for build-mgr to know the field layout
+		recordAllocShape(struct_name);
+		sa["alloc-shapes"].push_back({
+			{"shape-kind","arr-struct"}, {"shape-key",shape_key}, {"struct-name",struct_name}
+		});
+	}
+
+	string alloc_func = "__pln_alloc_" + shape_key;
+	string free_func  = "__pln_free_"  + shape_key;
+
+	// LCOV_EXCL_EXCEPTION_BR_START
+	json uint64_type = {{"type-kind","prim"},{"type-name","uint64"}};
+	json struct_type = {{"type-kind","struct"},{"type-name",struct_name}};
+	json elem_pntr   = {{"type-kind","pntr"},{"base-type",struct_type}};
+	json pntr_type   = {{"type-kind","pntr"},{"base-type",elem_pntr}};
+	// LCOV_EXCL_EXCEPTION_BR_STOP
+	const PlnType* uint64Type = registry_.prim(PrimType::Name::Uint64);
+
+	auto checkIntSize = [&](const json& sz) {
+		if (!sz.contains("value-type")) return;
+		const PlnType* t = registry_.fromJson(sz["value-type"]);
+		bool is_int = t->kind == PlnType::Kind::Prim
+			&& static_cast<const PrimType*>(t)->name != PrimType::Name::Float32
+			&& static_cast<const PrimType*>(t)->name != PrimType::Name::Float64;
+		if (!is_int) {
+			cerr << locPrefix(stmt) << PlnSaMessage::getMessage(E_ArraySizeNotInteger) << endl;
+			exit(1);
+		}
+	};
+
+	json result = json::array();
+	for (auto& var : stmt["vars"]) {
+		string name = var["name"];
+		string n_name = "__" + name + "_n";
+
+		json n_expr = sa_expression(vtype["size-expr"], uint64Type);
+		checkIntSize(n_expr);
+
+		// LCOV_EXCL_EXCEPTION_BR_START
+		json n_id = {{"expr-type","id"},{"name",n_name},
+		             {"var-type",uint64_type},{"value-type",uint64_type}};
+		json arr_id = {{"expr-type","id"},{"name",name},
+		               {"var-type",pntr_type},{"value-type",pntr_type}};
+		// LCOV_EXCL_EXCEPTION_BR_STOP
+
+		declareVar(n_name, uint64_type, &stmt);
+		// LCOV_EXCL_EXCEPTION_BR_START
+		result.push_back({{"stmt-type","var-decl"},{"vars",json::array({{
+			{"name",n_name},{"var-type",uint64_type},{"init",n_expr}
+		}})}});
+		// LCOV_EXCL_EXCEPTION_BR_STOP
+
+		json alloc_call = {
+			{"expr-type","call"}, {"name",alloc_func}, {"func-type","palan"},
+			{"args",json::array({n_id})}, {"value-type",pntr_type}
+		};
+		json free_stmt_json = {{"stmt-type","expr"},{"body",{
+			{"expr-type","call"}, {"name",free_func}, {"func-type","palan"},
+			{"args",json::array({arr_id, n_id})}
+		}}};
+
+		declareVar(name, pntr_type, &stmt);
+		arrayScopeVars_.back().push_back({name, free_stmt_json});
+		// LCOV_EXCL_EXCEPTION_BR_START
+		result.push_back({{"stmt-type","var-decl"},{"vars",json::array({{
+			{"name",name},{"var-type",pntr_type},{"init",alloc_call}
+		}})}});
+		// LCOV_EXCL_EXCEPTION_BR_STOP
+	}
 	return result;
 } // LCOV_EXCL_EXCEPTION_BR_LINE

--- a/src/semantic-anlyzr/PlnSaDecl.cpp
+++ b/src/semantic-anlyzr/PlnSaDecl.cpp
@@ -250,9 +250,17 @@ json PlnSemanticAnalyzer::sa_arr_var_decl(const json& stmt)
 	int elem_size;
 	json sa_elem_type;
 	if (base_type.value("type-kind","") == "pntr") {
-		// [n]@![]T: elem is mutable pntr to unsized arr → size = 8, SA elem = pntr(T)
+		const json& inner = base_type["base-type"];
 		elem_size = 8;
-		sa_elem_type = unsizedArrToPntr(base_type["base-type"]);
+		if (inner.value("type-kind","") == "prim" && structDefs_.count(inner.value("type-name",""))) {
+			// [n]@T / [n]@!T: elem is non-owning pntr to struct → SA elem = pntr(struct(T), mutable:bool)
+			json struct_type = {{"type-kind","struct"},{"type-name",inner["type-name"]}};
+			sa_elem_type = {{"type-kind","pntr"},{"base-type",struct_type},
+			                {"mutable",base_type.value("mutable", false)}};
+		} else {
+			// [n]@![]T: elem is mutable pntr to unsized arr → SA elem = pntr(T)
+			sa_elem_type = unsizedArrToPntr(inner);
+		}
 	} else {
 		elem_size = elemSizeBytes(base_type.value("type-name",""));
 		sa_elem_type = base_type;

--- a/src/semantic-anlyzr/PlnSaDecl.cpp
+++ b/src/semantic-anlyzr/PlnSaDecl.cpp
@@ -320,8 +320,52 @@ json PlnSemanticAnalyzer::sa_arr_var_decl(const json& stmt)
 
 json PlnSemanticAnalyzer::sa_embed_arr_var_decl(const json& stmt)
 {
+	const json& vtype = stmt["vars"][0]["var-type"];
+	string base_kind = vtype["base-type"].value("type-kind", "");
+
+	// [n]$T: contiguous 1D struct array — single malloc(n * totalSize), free at scope exit
+	if (base_kind == "prim") {
+		string leaf_name = vtype["base-type"].value("type-name", "");
+		if (!structDefs_.count(leaf_name)) {
+			cerr << locPrefix(stmt) << PlnSaMessage::getMessage(E_UnknownStructType, leaf_name) << endl;
+			exit(1);
+		}
+		const StructDef& def = structDefs_[leaf_name];
+		if (def.hasOwnedStructFields) {
+			cerr << locPrefix(stmt) << PlnSaMessage::getMessage(E_EmbedArrOwnedSubStruct) << endl;
+			exit(1);
+		}
+		int stride = def.totalSize;
+		// LCOV_EXCL_EXCEPTION_BR_START
+		json uint64_type  = {{"type-kind","prim"},{"type-name","uint64"}};
+		// LCOV_EXCL_EXCEPTION_BR_STOP
+		const PlnType* uint64Type = registry_.prim(PrimType::Name::Uint64);
+		// LCOV_EXCL_EXCEPTION_BR_START
+		json struct_base = {{"type-kind","struct"},{"type-name",leaf_name}};
+		json pntr_type   = {{"type-kind","pntr"},{"embedded",true},{"stride",stride},{"base-type",struct_base}};
+		// LCOV_EXCL_EXCEPTION_BR_STOP
+		json result = json::array();
+		for (auto& var : stmt["vars"]) {
+			string name = var["name"];
+			json sa_outer = sa_expression(vtype["size-expr"], uint64Type);
+			// LCOV_EXCL_EXCEPTION_BR_START
+			json stride_lit = {{"expr-type","lit-uint"},{"value",to_string(stride)},{"value-type",uint64_type}};
+			json size_arg   = {{"expr-type","mul"},{"value-type",uint64_type},{"left",sa_outer},{"right",stride_lit}};
+			json malloc_call = {{"expr-type","call"},{"name","malloc"},{"func-type","c"},
+			                    {"args",json::array({size_arg})},{"value-type",pntr_type}};
+			// LCOV_EXCL_EXCEPTION_BR_STOP
+			declareVar(name, pntr_type, &stmt);
+			arrayScopeVars_.back().push_back({name, makeFreeStmt(name, pntr_type)});
+			// LCOV_EXCL_EXCEPTION_BR_START
+			result.push_back({{"stmt-type","var-decl"},{"vars",json::array({{
+				{"name",name},{"var-type",pntr_type},{"init",malloc_call}
+			}})}});
+			// LCOV_EXCL_EXCEPTION_BR_STOP
+		}
+		return result;
+	}
+
 	// [n]$[m]T: contiguous 2D array — single malloc(n * stride), free at scope exit
-	const json& vtype     = stmt["vars"][0]["var-type"];
 	const json& inner_arr = vtype["base-type"];   // [m]T part
 	const json& leaf_type = inner_arr["base-type"]; // T (prim)
 	const json& inner_sz  = inner_arr["size-expr"]; // m AST node

--- a/src/semantic-anlyzr/PlnSaExpr.cpp
+++ b/src/semantic-anlyzr/PlnSaExpr.cpp
@@ -24,6 +24,16 @@ FieldChain PlnSemanticAnalyzer::resolveObjectChain(const json& obj)
 		}
 		return {false, varName, 0, {}, (*vt)["base-type"]["type-name"].get<string>()};
 	}
+	if (obj.value("expr-type","") == "arr-index") {
+		json sa_idx = sa_expression(obj);
+		const json& vt = sa_idx["value-type"];
+		if (vt.value("type-kind","") != "pntr" || vt["base-type"].value("type-kind","") != "struct") {
+			cerr << locPrefix(obj) << PlnSaMessage::getMessage(E_FieldAccessOnNonStruct) << endl;
+			exit(1);
+		}
+		string struct_name = vt["base-type"]["type-name"].get<string>();
+		return {true, "", 0, move(sa_idx), struct_name};
+	}
 	FieldChain base = resolveObjectChain(obj["object"]);
 	string fn = obj["field"].get<string>();
 	const StructDef& def = structDefs_[base.structName];

--- a/src/semantic-anlyzr/PlnSaExpr.cpp
+++ b/src/semantic-anlyzr/PlnSaExpr.cpp
@@ -375,6 +375,21 @@ json PlnSemanticAnalyzer::sa_expr_arr_index(const json& expr)
 	json uint64_type = {{"type-kind","prim"},{"type-name","uint64"}};
 
 	if (array_type.value("embedded", false)) {
+		if (elem_type.value("type-kind", "") == "struct") {
+			// [n]$T contiguous struct array: pts[i] -> pntr(struct(T)), inline address
+			// (stride = T.totalSize, carried on array_type; arr-index itself does not deref)
+			int64_t stride = array_type.value("stride", (int64_t)0);
+			json row_pntr = {{"type-kind","pntr"},{"base-type",elem_type}};
+			json elem_size_node = {
+				{"expr-type","lit-uint"},{"value",to_string(stride)},{"value-type",uint64_type}
+			};
+			sa_expr["array"]      = sa_array;
+			sa_expr["index"]      = sa_index;
+			sa_expr["elem-size"]  = elem_size_node;
+			sa_expr["value-type"] = row_pntr;
+			return sa_expr;
+		}
+
 		// Embedded 2D array row access: mat[i] → pntr(T), non-owning
 		// elem-size = stride = inner-size * sizeof(T)  (or __name_d1 * sizeof(T) if variable)
 		int elem_sz = elemSizeBytes(elem_type.value("type-name",""));

--- a/src/semantic-anlyzr/PlnSaMessage.cpp
+++ b/src/semantic-anlyzr/PlnSaMessage.cpp
@@ -168,6 +168,9 @@ string PlnSaMessage::getMessage(PlnSaMessageCode msg_code, string arg1, string a
 		case E_EmbedArrOwnedSubStruct:
 			return "[n]$T: T has owned sub-struct fields; use [n]T instead.";
 
+		case E_WriteToReadOnlyArrElem:
+			return "cannot write through read-only pointer array element; use [n]@!T for mutable.";
+
 		default:
 			BOOST_ASSERT(false);
 	}

--- a/src/semantic-anlyzr/PlnSaMessage.cpp
+++ b/src/semantic-anlyzr/PlnSaMessage.cpp
@@ -165,6 +165,9 @@ string PlnSaMessage::getMessage(PlnSaMessageCode msg_code, string arg1, string a
 		case E_WriteToImmutablePtrField:
 			return "cannot write through read-only pointer field '@T'; use '@!T' for mutable.";
 
+		case E_EmbedArrOwnedSubStruct:
+			return "[n]$T: T has owned sub-struct fields; use [n]T instead.";
+
 		default:
 			BOOST_ASSERT(false);
 	}

--- a/src/semantic-anlyzr/PlnSaMessage.h
+++ b/src/semantic-anlyzr/PlnSaMessage.h
@@ -50,6 +50,7 @@ enum PlnSaMessageCode {
 	E_FieldAccessOnNonStruct,
 	E_InlineStructAsValue,
 	E_WriteToImmutablePtrField,
+	E_EmbedArrOwnedSubStruct,
 };
 
 class PlnSaMessage

--- a/src/semantic-anlyzr/PlnSaMessage.h
+++ b/src/semantic-anlyzr/PlnSaMessage.h
@@ -51,6 +51,7 @@ enum PlnSaMessageCode {
 	E_InlineStructAsValue,
 	E_WriteToImmutablePtrField,
 	E_EmbedArrOwnedSubStruct,
+	E_WriteToReadOnlyArrElem,
 };
 
 class PlnSaMessage

--- a/src/semantic-anlyzr/PlnSaStmt.cpp
+++ b/src/semantic-anlyzr/PlnSaStmt.cpp
@@ -406,6 +406,23 @@ FieldChain PlnSemanticAnalyzer::resolveStoreLocChain(const json& loc)
 		}
 		return {false, varName, 0, {}, (*vt)["base-type"]["type-name"].get<string>()};
 	}
+	if (loc.value("kind","") == "arr-index") {
+		json arr_expr = loc;
+		arr_expr["expr-type"] = "arr-index";
+		arr_expr.erase("kind");
+		json sa_idx = sa_expression(arr_expr);
+		const json& vt = sa_idx["value-type"];
+		if (vt.value("type-kind","") != "pntr" || vt["base-type"].value("type-kind","") != "struct") {
+			cerr << locPrefix(loc) << PlnSaMessage::getMessage(E_FieldAccessOnNonStruct) << endl;
+			exit(1);
+		}
+		if (vt.value("mutable", true) == false) {
+			cerr << locPrefix(loc) << PlnSaMessage::getMessage(E_WriteToReadOnlyArrElem) << endl;
+			exit(1);
+		}
+		string struct_name = vt["base-type"]["type-name"].get<string>();
+		return {true, "", 0, move(sa_idx), struct_name};
+	}
 	FieldChain base = resolveStoreLocChain(loc["base"]);
 	string fn = loc["field"].get<string>();
 	const StructDef& def = structDefs_[base.structName];

--- a/src/semantic-anlyzr/PlnSaStmt.cpp
+++ b/src/semantic-anlyzr/PlnSaStmt.cpp
@@ -181,11 +181,11 @@ void PlnSemanticAnalyzer::sa_function(const json& funcDef)
 
 	if (funcDef.contains("parameters"))
 		for (auto& p : funcDef["parameters"])
-			declareVar(p["name"], toStructPntrType(unsizedArrToPntr(p["var-type"])), &funcDef);
+			declareVar(p["name"], deepNormalizePrimToStruct(toStructPntrType(unsizedArrToPntr(p["var-type"]))), &funcDef);
 	if (funcDef.contains("rets"))
 		for (auto& r : funcDef["rets"])
 			if (!isStructType(r["var-type"]))
-				declareVar(r["name"], unsizedArrToPntr(r["var-type"]), &funcDef);
+				declareVar(r["name"], deepNormalizePrimToStruct(unsizedArrToPntr(r["var-type"])), &funcDef);
 
 	currentFunc_ = findPlnFunc(funcDef["name"]);
 	enterScope();  // push scope[1] = function body

--- a/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
+++ b/src/semantic-anlyzr/PlnSemanticAnalyzer.cpp
@@ -244,18 +244,42 @@ bool PlnSemanticAnalyzer::isNamedReturnVar(const string& varName) const
 	return false;
 }
 
+json PlnSemanticAnalyzer::deepNormalizePrimToStruct(const json& type) const
+{
+	// Recursively convert prim(Name) → struct(Name) inside pntr chains.
+	// Needed when struct types appear nested in pointer-of-pointer signatures like []@!T.
+	if (type.value("type-kind","") == "pntr") {
+		json t = type;
+		t["base-type"] = deepNormalizePrimToStruct(type["base-type"]);
+		return t;
+	}
+	if (isStructType(type))
+		return {{"type-kind","struct"},{"type-name",type["type-name"]}};
+	return type;
+} // LCOV_EXCL_EXCEPTION_BR_LINE
+
 void PlnSemanticAnalyzer::normalizeStructSig(json& funcDef)
 {
 	if (funcDef.contains("parameters"))
-		for (auto& p : funcDef["parameters"])
+		for (auto& p : funcDef["parameters"]) {
 			if (isStructType(p["var-type"]))
 				p["var-type"] = toStructPntrType(p["var-type"]);
+			else
+				p["var-type"] = deepNormalizePrimToStruct(p["var-type"]);
+		}
 	if (funcDef.contains("rets"))
-		for (auto& r : funcDef["rets"])
+		for (auto& r : funcDef["rets"]) {
 			if (isStructType(r["var-type"]))
 				r["var-type"] = toStructPntrType(r["var-type"]);
-	if (funcDef.contains("ret-type") && isStructType(funcDef["ret-type"]))
-		funcDef["ret-type"] = toStructPntrType(funcDef["ret-type"]);
+			else
+				r["var-type"] = deepNormalizePrimToStruct(r["var-type"]);
+		}
+	if (funcDef.contains("ret-type")) {
+		if (isStructType(funcDef["ret-type"]))
+			funcDef["ret-type"] = toStructPntrType(funcDef["ret-type"]);
+		else
+			funcDef["ret-type"] = deepNormalizePrimToStruct(funcDef["ret-type"]);
+	}
 }
 
 void PlnSemanticAnalyzer::analysis(const json &ast)

--- a/src/semantic-anlyzr/PlnSemanticAnalyzer.h
+++ b/src/semantic-anlyzr/PlnSemanticAnalyzer.h
@@ -107,6 +107,7 @@ class PlnSemanticAnalyzer {
 	bool isStructType(const json& type) const;
 	json  toStructPntrType(const json& type) const;
 	bool  isNamedReturnVar(const string& varName) const;
+	json  deepNormalizePrimToStruct(const json& type) const;
 	void  normalizeStructSig(json& funcDef);
 	json sa_field_assign(const json& stmt);
 	FieldChain resolveObjectChain(const json& obj);

--- a/src/semantic-anlyzr/PlnSemanticAnalyzer.h
+++ b/src/semantic-anlyzr/PlnSemanticAnalyzer.h
@@ -100,6 +100,7 @@ class PlnSemanticAnalyzer {
 	json sa_var_decl(const json& stmt);           // returns array of statements
 	json sa_arr_var_decl(const json& stmt);       // returns array of statements
 	json sa_embed_arr_var_decl(const json& stmt); // returns array of statements
+	json sa_owned_struct_arr_var_decl(const json& stmt); // returns array of statements
 	json sa_struct_def(const json& stmt);         // consume struct-def, register in structDefs_
 	json sa_struct_var_decl(const json& stmt);    // returns array of statements
 	void recordAllocShape(const string& structName);

--- a/test/build-mgr-tester/basicTests.cpp
+++ b/test/build-mgr-tester/basicTests.cpp
@@ -425,6 +425,12 @@ TEST(build_mgr, struct_func_param) {
 	ASSERT_EQ(output, "42\n");
 }
 
+TEST(build_mgr, owned_struct_arr) {
+	cleanTestEnv();
+	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/061_owned_struct_arr.pa");
+	ASSERT_EQ(output, "5 6 7 8\n");
+}
+
 TEST(build_mgr, clean) {
 	cleanTestEnv();
 

--- a/test/build-mgr-tester/basicTests.cpp
+++ b/test/build-mgr-tester/basicTests.cpp
@@ -449,6 +449,97 @@ TEST(build_mgr, at_bang_struct_arr) {
 	ASSERT_EQ(output, "42 20\n");
 }
 
+static pair<int,int> parseMtraceLog(const string& traceFile) {
+	string log = execTestCommand("cat " + traceFile);
+	int allocs = 0, frees = 0;
+	size_t pos = 0;
+	while ((pos = log.find("@ ", pos)) != string::npos) {
+		size_t eol = log.find('\n', pos);
+		string line = log.substr(pos, eol - pos);
+		bool fromSharedLib = line.find(".so.") != string::npos;
+		if (!fromSharedLib && line.find(" + ") != string::npos) allocs++;
+		if (line.find(" - ") != string::npos) frees++;
+		pos = (eol == string::npos) ? string::npos : eol + 1;
+	}
+	return {allocs, frees};
+}
+
+TEST(build_mgr, owned_struct_arr_mtrace) {
+	cleanTestEnv();
+	ASSERT_EQ(execTestCommand(
+		"bin/palan -o /tmp/palan_owned_struct_arr_mtrace_bin "
+		"../test/testdata/build-mgr/065_owned_struct_arr_mtrace.pa"), "");
+
+	string traceFile = "/tmp/palan_owned_struct_arr_mtrace.log";
+	execTestCommand(
+		"env LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libc_malloc_debug.so "
+		"MALLOC_TRACE=" + traceFile + " "
+		"/tmp/palan_owned_struct_arr_mtrace_bin");
+
+	auto [allocs, frees] = parseMtraceLog(traceFile);
+	// [2]Point pts: 1 malloc (ptr array) + 2 calloc (Point elements) = 3 allocs
+	EXPECT_EQ(allocs, 3) << "expected 3 allocs for [2]Point pts, got " << allocs;
+	EXPECT_EQ(allocs, frees)
+		<< "malloc/free not balanced: " << allocs << " allocs, " << frees << " frees";
+}
+
+TEST(build_mgr, embed_struct_arr_mtrace) {
+	cleanTestEnv();
+	ASSERT_EQ(execTestCommand(
+		"bin/palan -o /tmp/palan_embed_struct_arr_mtrace_bin "
+		"../test/testdata/build-mgr/066_embed_struct_arr_mtrace.pa"), "");
+
+	string traceFile = "/tmp/palan_embed_struct_arr_mtrace.log";
+	execTestCommand(
+		"env LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libc_malloc_debug.so "
+		"MALLOC_TRACE=" + traceFile + " "
+		"/tmp/palan_embed_struct_arr_mtrace_bin");
+
+	auto [allocs, frees] = parseMtraceLog(traceFile);
+	// [3]$Point pts: 1 malloc (contiguous block n*stride), 1 free
+	EXPECT_EQ(allocs, 1) << "expected 1 malloc for [3]$Point pts, got " << allocs;
+	EXPECT_EQ(allocs, frees)
+		<< "malloc/free not balanced: " << allocs << " allocs, " << frees << " frees";
+}
+
+TEST(build_mgr, at_struct_arr_mtrace) {
+	cleanTestEnv();
+	ASSERT_EQ(execTestCommand(
+		"bin/palan -o /tmp/palan_at_struct_arr_mtrace_bin "
+		"../test/testdata/build-mgr/067_at_struct_arr_mtrace.pa"), "");
+
+	string traceFile = "/tmp/palan_at_struct_arr_mtrace.log";
+	execTestCommand(
+		"env LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libc_malloc_debug.so "
+		"MALLOC_TRACE=" + traceFile + " "
+		"/tmp/palan_at_struct_arr_mtrace_bin");
+
+	auto [allocs, frees] = parseMtraceLog(traceFile);
+	// [4]@Point rpts: 1 malloc (ptr array), 1 free; Point p is outside mtrace scope
+	EXPECT_EQ(allocs, 1) << "expected 1 malloc for [4]@Point rpts, got " << allocs;
+	EXPECT_EQ(allocs, frees)
+		<< "malloc/free not balanced: " << allocs << " allocs, " << frees << " frees";
+}
+
+TEST(build_mgr, at_bang_struct_arr_mtrace) {
+	cleanTestEnv();
+	ASSERT_EQ(execTestCommand(
+		"bin/palan -o /tmp/palan_at_bang_struct_arr_mtrace_bin "
+		"../test/testdata/build-mgr/068_at_bang_struct_arr_mtrace.pa"), "");
+
+	string traceFile = "/tmp/palan_at_bang_struct_arr_mtrace.log";
+	execTestCommand(
+		"env LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libc_malloc_debug.so "
+		"MALLOC_TRACE=" + traceFile + " "
+		"/tmp/palan_at_bang_struct_arr_mtrace_bin");
+
+	auto [allocs, frees] = parseMtraceLog(traceFile);
+	// [4]@!Point wpts: 1 malloc (ptr array), 1 free; Point p is outside mtrace scope
+	EXPECT_EQ(allocs, 1) << "expected 1 malloc for [4]@!Point wpts, got " << allocs;
+	EXPECT_EQ(allocs, frees)
+		<< "malloc/free not balanced: " << allocs << " allocs, " << frees << " frees";
+}
+
 TEST(build_mgr, clean) {
 	cleanTestEnv();
 

--- a/test/build-mgr-tester/basicTests.cpp
+++ b/test/build-mgr-tester/basicTests.cpp
@@ -431,6 +431,24 @@ TEST(build_mgr, owned_struct_arr) {
 	ASSERT_EQ(output, "5 6 7 8\n");
 }
 
+TEST(build_mgr, embed_struct_arr) {
+	cleanTestEnv();
+	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/062_embed_struct_arr.pa");
+	ASSERT_EQ(output, "30 40\n");
+}
+
+TEST(build_mgr, at_struct_arr) {
+	cleanTestEnv();
+	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/063_at_struct_arr.pa");
+	ASSERT_EQ(output, "99 77\n");
+}
+
+TEST(build_mgr, at_bang_struct_arr) {
+	cleanTestEnv();
+	string output = execTestCommand("bin/palan ../test/testdata/build-mgr/064_at_bang_struct_arr.pa");
+	ASSERT_EQ(output, "42 20\n");
+}
+
 TEST(build_mgr, clean) {
 	cleanTestEnv();
 

--- a/test/gen-ast-tester/basicTests.cpp
+++ b/test/gen-ast-tester/basicTests.cpp
@@ -790,3 +790,66 @@ TEST(gen_ast, mutable_ptr_struct_field) {
 	ASSERT_EQ(s["fields"][1]["var-type"]["mutable"], true);
 	ASSERT_EQ(s["fields"][1]["var-type"]["base-type"]["type-name"], "Node");
 }
+
+TEST(gen_ast, arr_at_struct) {
+	cleanTestEnv();
+	string output = execTestCommand("bin/palan-gen-ast ../test/testdata/gen-ast/028_arr_at_struct.pa");
+	ASSERT_TRUE(checkerr(output));
+	json jout = json::parse(output);
+	const auto& stmts = jout["ast"]["statements"];
+	ASSERT_EQ(stmts.size(), 2);
+
+	// [4]@Point rpts;
+	const auto& decl = stmts[1];
+	ASSERT_EQ(decl["stmt-type"], "var-decl");
+	const auto& vt = decl["vars"][0]["var-type"];
+	ASSERT_EQ(vt["type-kind"], "arr");
+	ASSERT_EQ(vt["specifier"], "raw");
+	ASSERT_EQ(vt["size-expr"]["value"], "4");
+	ASSERT_EQ(vt["base-type"]["type-kind"], "pntr");
+	ASSERT_FALSE(vt["base-type"].value("mutable", false));
+	ASSERT_EQ(vt["base-type"]["base-type"]["type-kind"], "prim");
+	ASSERT_EQ(vt["base-type"]["base-type"]["type-name"], "Point");
+}
+
+TEST(gen_ast, arr_at_bang_struct) {
+	cleanTestEnv();
+	string output = execTestCommand("bin/palan-gen-ast ../test/testdata/gen-ast/029_arr_at_bang_struct.pa");
+	ASSERT_TRUE(checkerr(output));
+	json jout = json::parse(output);
+	const auto& stmts = jout["ast"]["statements"];
+	ASSERT_EQ(stmts.size(), 2);
+
+	// [4]@!Point wpts;
+	const auto& decl = stmts[1];
+	ASSERT_EQ(decl["stmt-type"], "var-decl");
+	const auto& vt = decl["vars"][0]["var-type"];
+	ASSERT_EQ(vt["type-kind"], "arr");
+	ASSERT_EQ(vt["specifier"], "raw");
+	ASSERT_EQ(vt["size-expr"]["value"], "4");
+	ASSERT_EQ(vt["base-type"]["type-kind"], "pntr");
+	ASSERT_EQ(vt["base-type"]["mutable"], true);
+	ASSERT_EQ(vt["base-type"]["base-type"]["type-kind"], "prim");
+	ASSERT_EQ(vt["base-type"]["base-type"]["type-name"], "Point");
+}
+
+TEST(gen_ast, func_arr_at_struct_param) {
+	cleanTestEnv();
+	string output = execTestCommand("bin/palan-gen-ast ../test/testdata/gen-ast/030_func_arr_at_struct_param.pa");
+	ASSERT_TRUE(checkerr(output));
+	json jout = json::parse(output);
+	const auto& funcs = jout["ast"]["functions"];
+	ASSERT_EQ(funcs.size(), 1);
+
+	// func f([]@!Point pts, int64 n) { }
+	const auto& params = funcs[0]["parameters"];
+	ASSERT_EQ(params.size(), 2);
+	const auto& vt = params[0]["var-type"];
+	ASSERT_EQ(vt["type-kind"], "arr");
+	ASSERT_EQ(vt["specifier"], "raw");
+	ASSERT_TRUE(vt["size-expr"].is_null());
+	ASSERT_EQ(vt["base-type"]["type-kind"], "pntr");
+	ASSERT_EQ(vt["base-type"]["mutable"], true);
+	ASSERT_EQ(vt["base-type"]["base-type"]["type-kind"], "prim");
+	ASSERT_EQ(vt["base-type"]["base-type"]["type-name"], "Point");
+}

--- a/test/sa-tester/basicTests.cpp
+++ b/test/sa-tester/basicTests.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <fstream>
+#include <algorithm>
 #include "../test-base/testBase.h"
 #include "../../lib/json/single_include/nlohmann/json.hpp"
 
@@ -1989,4 +1990,59 @@ TEST(sa, embed_struct_arr_decl)
 	ASSERT_EQ(last["stmt-type"], "expr");
 	ASSERT_EQ(last["body"]["name"], "free");
 	ASSERT_EQ(last["body"]["args"][0]["name"], "pts");
+}
+
+TEST(sa, owned_struct_arr_decl)
+{
+	// [2]Point pts — owned pointer array: alloc/free via palan functions
+	cleanTestEnv();
+	json jout = run_sa("../test/testdata/sa/099_owned_struct_arr.pa");
+	ASSERT_TRUE(jout.is_object());
+
+	// alloc-shapes: struct shape for Point, then arr-struct shape for arr_Point
+	const auto& shapes = jout["alloc-shapes"];
+	ASSERT_GE(shapes.size(), 2u);
+	auto arr_it = find_if(shapes.begin(), shapes.end(), [](const json& s){
+		return s.value("shape-kind","") == "arr-struct";
+	});
+	ASSERT_NE(arr_it, shapes.end());
+	ASSERT_EQ((*arr_it)["shape-key"],   "arr_Point");
+	ASSERT_EQ((*arr_it)["struct-name"], "Point");
+
+	auto struct_it = find_if(shapes.begin(), shapes.end(), [](const json& s){
+		return s.value("shape-kind","") == "struct";
+	});
+	ASSERT_NE(struct_it, shapes.end());
+	ASSERT_EQ((*struct_it)["shape-name"], "Point");
+
+	ASSERT_FALSE(jout["functions"].empty());
+	const auto& body = jout["functions"][0]["body"];
+	ASSERT_GE(body.size(), 2u);
+
+	// body[0]: __pts_n = 2  (uint64 temp for count)
+	ASSERT_EQ(body[0]["stmt-type"], "var-decl");
+	ASSERT_EQ(body[0]["vars"][0]["name"], "__pts_n");
+	ASSERT_EQ(body[0]["vars"][0]["var-type"]["type-name"], "uint64");
+
+	// body[1]: pts = __pln_alloc_arr_Point(__pts_n)
+	ASSERT_EQ(body[1]["stmt-type"], "var-decl");
+	ASSERT_EQ(body[1]["vars"][0]["name"], "pts");
+	const auto& vt = body[1]["vars"][0]["var-type"];
+	ASSERT_EQ(vt["type-kind"], "pntr");
+	ASSERT_EQ(vt["base-type"]["type-kind"], "pntr");
+	ASSERT_EQ(vt["base-type"]["base-type"]["type-kind"], "struct");
+	ASSERT_EQ(vt["base-type"]["base-type"]["type-name"], "Point");
+	const auto& init = body[1]["vars"][0]["init"];
+	ASSERT_EQ(init["expr-type"], "call");
+	ASSERT_EQ(init["name"],      "__pln_alloc_arr_Point");
+	ASSERT_EQ(init["func-type"], "palan");
+	ASSERT_EQ(init["args"][0]["name"], "__pts_n");
+
+	// body.back(): __pln_free_arr_Point(pts, __pts_n)  at scope exit
+	const auto& last = body.back();
+	ASSERT_EQ(last["stmt-type"], "expr");
+	ASSERT_EQ(last["body"]["name"],      "__pln_free_arr_Point");
+	ASSERT_EQ(last["body"]["func-type"], "palan");
+	ASSERT_EQ(last["body"]["args"][0]["name"], "pts");
+	ASSERT_EQ(last["body"]["args"][1]["name"], "__pts_n");
 }

--- a/test/sa-tester/basicTests.cpp
+++ b/test/sa-tester/basicTests.cpp
@@ -1954,3 +1954,39 @@ TEST(sa, import_absolute_path)
 			{ found = true; break; }
 	ASSERT_TRUE(found);
 }
+
+TEST(sa, embed_struct_arr_decl)
+{
+	// [4]$Point pts — contiguous 1D struct array: malloc(4 * 16), free at scope exit
+	cleanTestEnv();
+	json jout = run_sa("../test/testdata/sa/098_embed_struct_arr.pa");
+	ASSERT_TRUE(jout.is_object());
+
+	ASSERT_FALSE(jout["functions"].empty());
+	const auto& body = jout["functions"][0]["body"];
+	ASSERT_GE(body.size(), 2u);
+
+	// body[0]: pts = malloc(4 * 16)
+	ASSERT_EQ(body[0]["stmt-type"], "var-decl");
+	ASSERT_EQ(body[0]["vars"][0]["name"], "pts");
+
+	const auto& vt = body[0]["vars"][0]["var-type"];
+	ASSERT_EQ(vt["type-kind"], "pntr");
+	ASSERT_TRUE(vt.value("embedded", false));
+	ASSERT_EQ(vt["stride"], 16);
+	ASSERT_EQ(vt["base-type"]["type-kind"], "struct");
+	ASSERT_EQ(vt["base-type"]["type-name"], "Point");
+
+	const auto& init = body[0]["vars"][0]["init"];
+	ASSERT_EQ(init["name"],      "malloc");
+	ASSERT_EQ(init["expr-type"], "call");
+	ASSERT_EQ(init["args"][0]["expr-type"],          "mul");
+	ASSERT_EQ(init["args"][0]["right"]["expr-type"], "lit-uint");
+	ASSERT_EQ(init["args"][0]["right"]["value"],     "16");
+
+	// body.back(): free(pts)
+	const auto& last = body.back();
+	ASSERT_EQ(last["stmt-type"], "expr");
+	ASSERT_EQ(last["body"]["name"], "free");
+	ASSERT_EQ(last["body"]["args"][0]["name"], "pts");
+}

--- a/test/sa-tester/basicTests.cpp
+++ b/test/sa-tester/basicTests.cpp
@@ -1985,6 +1985,16 @@ TEST(sa, embed_struct_arr_decl)
 	ASSERT_EQ(init["args"][0]["right"]["expr-type"], "lit-uint");
 	ASSERT_EQ(init["args"][0]["right"]["value"],     "16");
 
+	// body[1]: expr pts[0] — arr-index, value-type pntr(struct(Point)), elem-size 16
+	const auto& idx = body[1]["body"];
+	ASSERT_EQ(idx["expr-type"], "arr-index");
+	ASSERT_EQ(idx["value-type"]["type-kind"], "pntr");
+	ASSERT_EQ(idx["value-type"]["base-type"]["type-kind"], "struct");
+	ASSERT_EQ(idx["value-type"]["base-type"]["type-name"], "Point");
+	ASSERT_FALSE(idx["value-type"].contains("mutable"));
+	ASSERT_EQ(idx["elem-size"]["expr-type"], "lit-uint");
+	ASSERT_EQ(idx["elem-size"]["value"], "16");
+
 	// body.back(): free(pts)
 	const auto& last = body.back();
 	ASSERT_EQ(last["stmt-type"], "expr");
@@ -2038,6 +2048,16 @@ TEST(sa, owned_struct_arr_decl)
 	ASSERT_EQ(init["func-type"], "palan");
 	ASSERT_EQ(init["args"][0]["name"], "__pts_n");
 
+	// body[2]: expr pts[0] — arr-index, value-type pntr(struct(Point)), elem-size 8
+	const auto& idx = body[2]["body"];
+	ASSERT_EQ(idx["expr-type"], "arr-index");
+	ASSERT_EQ(idx["value-type"]["type-kind"], "pntr");
+	ASSERT_EQ(idx["value-type"]["base-type"]["type-kind"], "struct");
+	ASSERT_EQ(idx["value-type"]["base-type"]["type-name"], "Point");
+	ASSERT_FALSE(idx["value-type"].contains("mutable"));
+	ASSERT_EQ(idx["elem-size"]["expr-type"], "lit-uint");
+	ASSERT_EQ(idx["elem-size"]["value"], "8");
+
 	// body.back(): __pln_free_arr_Point(pts, __pts_n)  at scope exit
 	const auto& last = body.back();
 	ASSERT_EQ(last["stmt-type"], "expr");
@@ -2077,6 +2097,16 @@ TEST(sa, at_struct_arr_decl)
 	ASSERT_EQ(init["args"][0]["right"]["expr-type"], "lit-uint");
 	ASSERT_EQ(init["args"][0]["right"]["value"],     "8");
 
+	// body[1]: expr rpts[0] — arr-index, value-type pntr(struct(Point), mutable:false), elem-size 8
+	const auto& idx = body[1]["body"];
+	ASSERT_EQ(idx["expr-type"], "arr-index");
+	ASSERT_EQ(idx["value-type"]["type-kind"], "pntr");
+	ASSERT_EQ(idx["value-type"]["base-type"]["type-kind"], "struct");
+	ASSERT_EQ(idx["value-type"]["base-type"]["type-name"], "Point");
+	ASSERT_EQ(idx["value-type"]["mutable"], false);
+	ASSERT_EQ(idx["elem-size"]["expr-type"], "lit-uint");
+	ASSERT_EQ(idx["elem-size"]["value"], "8");
+
 	// body.back(): free(rpts)
 	const auto& last = body.back();
 	ASSERT_EQ(last["stmt-type"], "expr");
@@ -2105,6 +2135,16 @@ TEST(sa, at_bang_struct_arr_decl)
 	ASSERT_EQ(elem_vt["mutable"], true);
 	ASSERT_EQ(elem_vt["base-type"]["type-kind"], "struct");
 	ASSERT_EQ(elem_vt["base-type"]["type-name"], "Point");
+
+	// body[1]: expr wpts[0] — arr-index, value-type pntr(struct(Point), mutable:true), elem-size 8
+	const auto& idx = body[1]["body"];
+	ASSERT_EQ(idx["expr-type"], "arr-index");
+	ASSERT_EQ(idx["value-type"]["type-kind"], "pntr");
+	ASSERT_EQ(idx["value-type"]["base-type"]["type-kind"], "struct");
+	ASSERT_EQ(idx["value-type"]["base-type"]["type-name"], "Point");
+	ASSERT_EQ(idx["value-type"]["mutable"], true);
+	ASSERT_EQ(idx["elem-size"]["expr-type"], "lit-uint");
+	ASSERT_EQ(idx["elem-size"]["value"], "8");
 
 	// body.back(): free(wpts)
 	const auto& last = body.back();

--- a/test/sa-tester/basicTests.cpp
+++ b/test/sa-tester/basicTests.cpp
@@ -2046,3 +2046,69 @@ TEST(sa, owned_struct_arr_decl)
 	ASSERT_EQ(last["body"]["args"][0]["name"], "pts");
 	ASSERT_EQ(last["body"]["args"][1]["name"], "__pts_n");
 }
+
+TEST(sa, at_struct_arr_decl)
+{
+	// [4]@Point rpts — non-owning read-only pointer array: malloc(4 * 8), free at scope exit
+	cleanTestEnv();
+	json jout = run_sa("../test/testdata/sa/100_at_struct_arr.pa");
+	ASSERT_TRUE(jout.is_object());
+
+	ASSERT_FALSE(jout["functions"].empty());
+	const auto& body = jout["functions"][0]["body"];
+	ASSERT_GE(body.size(), 2u);
+
+	// body[0]: rpts = malloc(4 * 8)
+	ASSERT_EQ(body[0]["stmt-type"], "var-decl");
+	ASSERT_EQ(body[0]["vars"][0]["name"], "rpts");
+
+	const auto& vt = body[0]["vars"][0]["var-type"];
+	ASSERT_EQ(vt["type-kind"], "pntr");
+	const auto& elem_vt = vt["base-type"];
+	ASSERT_EQ(elem_vt["type-kind"], "pntr");
+	ASSERT_EQ(elem_vt["mutable"], false);
+	ASSERT_EQ(elem_vt["base-type"]["type-kind"], "struct");
+	ASSERT_EQ(elem_vt["base-type"]["type-name"], "Point");
+
+	const auto& init = body[0]["vars"][0]["init"];
+	ASSERT_EQ(init["name"],      "malloc");
+	ASSERT_EQ(init["expr-type"], "call");
+	ASSERT_EQ(init["args"][0]["expr-type"],          "mul");
+	ASSERT_EQ(init["args"][0]["right"]["expr-type"], "lit-uint");
+	ASSERT_EQ(init["args"][0]["right"]["value"],     "8");
+
+	// body.back(): free(rpts)
+	const auto& last = body.back();
+	ASSERT_EQ(last["stmt-type"], "expr");
+	ASSERT_EQ(last["body"]["name"], "free");
+	ASSERT_EQ(last["body"]["args"][0]["name"], "rpts");
+}
+
+TEST(sa, at_bang_struct_arr_decl)
+{
+	// [4]@!Point wpts — non-owning mutable write-through pointer array
+	cleanTestEnv();
+	json jout = run_sa("../test/testdata/sa/102_at_bang_struct_arr.pa");
+	ASSERT_TRUE(jout.is_object());
+
+	ASSERT_FALSE(jout["functions"].empty());
+	const auto& body = jout["functions"][0]["body"];
+	ASSERT_GE(body.size(), 2u);
+
+	// body[0]: wpts = malloc(4 * 8)
+	ASSERT_EQ(body[0]["stmt-type"], "var-decl");
+	ASSERT_EQ(body[0]["vars"][0]["name"], "wpts");
+
+	const auto& vt = body[0]["vars"][0]["var-type"];
+	const auto& elem_vt = vt["base-type"];
+	ASSERT_EQ(elem_vt["type-kind"], "pntr");
+	ASSERT_EQ(elem_vt["mutable"], true);
+	ASSERT_EQ(elem_vt["base-type"]["type-kind"], "struct");
+	ASSERT_EQ(elem_vt["base-type"]["type-name"], "Point");
+
+	// body.back(): free(wpts)
+	const auto& last = body.back();
+	ASSERT_EQ(last["stmt-type"], "expr");
+	ASSERT_EQ(last["body"]["name"], "free");
+	ASSERT_EQ(last["body"]["args"][0]["name"], "wpts");
+}

--- a/test/sa-tester/basicTests.cpp
+++ b/test/sa-tester/basicTests.cpp
@@ -2152,3 +2152,117 @@ TEST(sa, at_bang_struct_arr_decl)
 	ASSERT_EQ(last["body"]["name"], "free");
 	ASSERT_EQ(last["body"]["args"][0]["name"], "wpts");
 }
+
+TEST(sa, embed_struct_arr_field_access)
+{
+	// [4]$Point pts; 10 -> pts[0].x; 20 -> pts[0].y; printf("%ld %ld\n", pts[0].x, pts[0].y);
+	// Covers: resolveObjectChain / resolveStoreLocChain arr-index base case (embedded struct array)
+	cleanTestEnv();
+	json jout = run_sa("../test/testdata/sa/103_embed_struct_arr_field.pa");
+	ASSERT_TRUE(jout.is_object());
+
+	ASSERT_FALSE(jout["functions"].empty());
+	const auto& body = jout["functions"][0]["body"];
+
+	// body[1]: 10 -> pts[0].x — field-assign, ptr-expr = pts[0] (arr-index), offset 0
+	const auto& fa_x = body[1];
+	ASSERT_EQ(fa_x["stmt-type"], "field-assign");
+	ASSERT_EQ(fa_x["offset"], 0);
+	ASSERT_EQ(fa_x["value-type"]["type-name"], "int64");
+	ASSERT_EQ(fa_x["value"]["value"], "10");
+	const auto& pe_x = fa_x["ptr-expr"];
+	ASSERT_EQ(pe_x["expr-type"], "arr-index");
+	ASSERT_EQ(pe_x["value-type"]["type-kind"], "pntr");
+	ASSERT_EQ(pe_x["value-type"]["base-type"]["type-kind"], "struct");
+	ASSERT_EQ(pe_x["value-type"]["base-type"]["type-name"], "Point");
+	ASSERT_FALSE(pe_x["value-type"].contains("mutable"));
+	ASSERT_EQ(pe_x["elem-size"]["value"], "16");
+
+	// body[2]: 20 -> pts[0].y — field-assign, offset 8
+	const auto& fa_y = body[2];
+	ASSERT_EQ(fa_y["stmt-type"], "field-assign");
+	ASSERT_EQ(fa_y["offset"], 8);
+	ASSERT_EQ(fa_y["value"]["value"], "20");
+
+	// body[3]: printf("%ld %ld\n", pts[0].x, pts[0].y) — field-access args, ptr-expr = arr-index
+	const auto& args = body[3]["body"]["args"];
+	ASSERT_EQ(args[1]["expr-type"], "field-access");
+	ASSERT_EQ(args[1]["offset"], 0);
+	ASSERT_EQ(args[1]["ptr-expr"]["expr-type"], "arr-index");
+	ASSERT_EQ(args[2]["expr-type"], "field-access");
+	ASSERT_EQ(args[2]["offset"], 8);
+	ASSERT_EQ(args[2]["ptr-expr"]["expr-type"], "arr-index");
+}
+
+TEST(sa, owned_struct_arr_field_access)
+{
+	// [2]Point pts; 5 -> pts[0].x; printf("%ld\n", pts[0].x);
+	// Covers: resolveObjectChain / resolveStoreLocChain arr-index base case (owned pointer array)
+	cleanTestEnv();
+	json jout = run_sa("../test/testdata/sa/104_owned_struct_arr_field.pa");
+	ASSERT_TRUE(jout.is_object());
+
+	ASSERT_FALSE(jout["functions"].empty());
+	const auto& body = jout["functions"][0]["body"];
+
+	// body[2]: 5 -> pts[0].x — field-assign, ptr-expr = pts[0] (arr-index), elem-size 8
+	const auto& fa = body[2];
+	ASSERT_EQ(fa["stmt-type"], "field-assign");
+	ASSERT_EQ(fa["offset"], 0);
+	ASSERT_EQ(fa["value-type"]["type-name"], "int64");
+	const auto& pe = fa["ptr-expr"];
+	ASSERT_EQ(pe["expr-type"], "arr-index");
+	ASSERT_EQ(pe["value-type"]["type-kind"], "pntr");
+	ASSERT_EQ(pe["value-type"]["base-type"]["type-name"], "Point");
+	ASSERT_FALSE(pe["value-type"].contains("mutable"));
+	ASSERT_EQ(pe["elem-size"]["value"], "8");
+
+	// body[3]: printf("%ld\n", pts[0].x) — field-access, ptr-expr = arr-index
+	const auto& fa_read = body[3]["body"]["args"][1];
+	ASSERT_EQ(fa_read["expr-type"], "field-access");
+	ASSERT_EQ(fa_read["offset"], 0);
+	ASSERT_EQ(fa_read["ptr-expr"]["expr-type"], "arr-index");
+}
+
+TEST(sa, at_bang_struct_arr_field_write)
+{
+	// Point p; [4]@!Point wpts; p -> wpts[0]; 42 -> wpts[0].x; printf("%ld\n", p.x);
+	// Covers: resolveStoreLocChain arr-index base case, mutable:true (write-through allowed)
+	cleanTestEnv();
+	json jout = run_sa("../test/testdata/sa/105_at_bang_struct_arr_field.pa");
+	ASSERT_TRUE(jout.is_object());
+
+	ASSERT_FALSE(jout["functions"].empty());
+	const auto& body = jout["functions"][0]["body"];
+
+	// body[3]: 42 -> wpts[0].x — field-assign, ptr-expr = wpts[0] (arr-index, mutable:true)
+	const auto& fa = body[3];
+	ASSERT_EQ(fa["stmt-type"], "field-assign");
+	ASSERT_EQ(fa["offset"], 0);
+	ASSERT_EQ(fa["value"]["value"], "42");
+	const auto& pe = fa["ptr-expr"];
+	ASSERT_EQ(pe["expr-type"], "arr-index");
+	ASSERT_EQ(pe["value-type"]["base-type"]["type-name"], "Point");
+	ASSERT_EQ(pe["value-type"]["mutable"], true);
+}
+
+TEST(sa, at_struct_arr_field_read)
+{
+	// Point p; [4]@Point rpts; p -> rpts[0]; printf("%ld\n", rpts[0].x);
+	// Covers: resolveObjectChain arr-index base case, mutable:false (read-only, read allowed)
+	cleanTestEnv();
+	json jout = run_sa("../test/testdata/sa/106_at_struct_arr_field_read.pa");
+	ASSERT_TRUE(jout.is_object());
+
+	ASSERT_FALSE(jout["functions"].empty());
+	const auto& body = jout["functions"][0]["body"];
+
+	// body[3]: printf("%ld\n", rpts[0].x) — field-access, ptr-expr = rpts[0] (arr-index, mutable:false)
+	const auto& fa = body[3]["body"]["args"][1];
+	ASSERT_EQ(fa["expr-type"], "field-access");
+	ASSERT_EQ(fa["offset"], 0);
+	const auto& pe = fa["ptr-expr"];
+	ASSERT_EQ(pe["expr-type"], "arr-index");
+	ASSERT_EQ(pe["value-type"]["base-type"]["type-name"], "Point");
+	ASSERT_EQ(pe["value-type"]["mutable"], false);
+}

--- a/test/sa-tester/errorTests.cpp
+++ b/test/sa-tester/errorTests.cpp
@@ -559,3 +559,16 @@ TEST(sa_error, alias_unknown_method)
 	ASSERT_NE(sa.find("Undefined function"), string::npos);
 }
 
+TEST(sa_error, embed_arr_owned_sub_struct)
+{
+	// [n]$Outer where Outer has an owned struct-ptr field — should error
+	// Covers: E_EmbedArrOwnedSubStruct in sa_embed_arr_var_decl
+	cleanTestEnv();
+	string ast_out = "out/test.ast.json";
+	ASSERT_EQ(execTestCommand(
+		"bin/palan-gen-ast ../test/testdata/sa/error_076_embed_arr_owned_struct.pa -o " + ast_out), "");
+	string sa = execTestCommand("bin/palan-sa " + ast_out + " -o out/test.sa.json");
+	ASSERT_NE(sa, "");
+	ASSERT_NE(sa.find("owned sub-struct"), string::npos);
+}
+

--- a/test/sa-tester/errorTests.cpp
+++ b/test/sa-tester/errorTests.cpp
@@ -572,3 +572,42 @@ TEST(sa_error, embed_arr_owned_sub_struct)
 	ASSERT_NE(sa.find("owned sub-struct"), string::npos);
 }
 
+TEST(sa_error, write_readonly_arr_elem)
+{
+	// [4]@Point rpts; 42 -> rpts[0].x; — write through read-only pointer array element
+	// Covers: resolveStoreLocChain arr-index base case, mutable:false branch (E_WriteToReadOnlyArrElem)
+	cleanTestEnv();
+	string ast_out = "out/test.ast.json";
+	ASSERT_EQ(execTestCommand(
+		"bin/palan-gen-ast ../test/testdata/sa/error_077_write_readonly_arr_elem.pa -o " + ast_out), "");
+	string sa = execTestCommand("bin/palan-sa " + ast_out + " -o out/test.sa.json");
+	ASSERT_NE(sa, "");
+	ASSERT_NE(sa.find("read-only pointer array element"), string::npos);
+}
+
+TEST(sa_error, field_access_on_arr_index_non_struct)
+{
+	// [4]int64 arr; printf("%ld\n", arr[0].x); — arr[i] is not a struct pointer
+	// Covers: resolveObjectChain arr-index base case, non-struct value-type branch (E_FieldAccessOnNonStruct)
+	cleanTestEnv();
+	string ast_out = "out/test.ast.json";
+	ASSERT_EQ(execTestCommand(
+		"bin/palan-gen-ast ../test/testdata/sa/error_078_field_access_on_arr_index_non_struct.pa -o " + ast_out), "");
+	string sa = execTestCommand("bin/palan-sa " + ast_out + " -o out/test.sa.json");
+	ASSERT_NE(sa, "");
+	ASSERT_NE(sa.find("field access on non-struct variable"), string::npos);
+}
+
+TEST(sa_error, field_assign_on_arr_index_non_struct)
+{
+	// [4]int64 arr; 10 -> arr[0].x; — arr[i] is not a struct pointer
+	// Covers: resolveStoreLocChain arr-index base case, non-struct value-type branch (E_FieldAccessOnNonStruct)
+	cleanTestEnv();
+	string ast_out = "out/test.ast.json";
+	ASSERT_EQ(execTestCommand(
+		"bin/palan-gen-ast ../test/testdata/sa/error_079_field_assign_on_arr_index_non_struct.pa -o " + ast_out), "");
+	string sa = execTestCommand("bin/palan-sa " + ast_out + " -o out/test.sa.json");
+	ASSERT_NE(sa, "");
+	ASSERT_NE(sa.find("field access on non-struct variable"), string::npos);
+}
+

--- a/test/testdata/build-mgr/061_owned_struct_arr.pa
+++ b/test/testdata/build-mgr/061_owned_struct_arr.pa
@@ -1,0 +1,6 @@
+cinclude <stdio.h>;
+type Point { int64 x; int64 y; };
+[2]Point pts;
+5 -> pts[0].x;  6 -> pts[0].y;
+7 -> pts[1].x;  8 -> pts[1].y;
+printf("%ld %ld %ld %ld\n", pts[0].x, pts[0].y, pts[1].x, pts[1].y);

--- a/test/testdata/build-mgr/062_embed_struct_arr.pa
+++ b/test/testdata/build-mgr/062_embed_struct_arr.pa
@@ -1,0 +1,7 @@
+cinclude <stdio.h>;
+type Point { int64 x; int64 y; };
+[3]$Point pts;
+10 -> pts[0].x;  20 -> pts[0].y;
+30 -> pts[1].x;  40 -> pts[1].y;
+50 -> pts[2].x;  60 -> pts[2].y;
+printf("%ld %ld\n", pts[1].x, pts[1].y);

--- a/test/testdata/build-mgr/063_at_struct_arr.pa
+++ b/test/testdata/build-mgr/063_at_struct_arr.pa
@@ -1,0 +1,7 @@
+cinclude <stdio.h>;
+type Point { int64 x; int64 y; };
+Point p;
+99 -> p.x;  77 -> p.y;
+[4]@Point rpts;
+p -> rpts[0];
+printf("%ld %ld\n", rpts[0].x, rpts[0].y);

--- a/test/testdata/build-mgr/064_at_bang_struct_arr.pa
+++ b/test/testdata/build-mgr/064_at_bang_struct_arr.pa
@@ -1,0 +1,8 @@
+cinclude <stdio.h>;
+type Point { int64 x; int64 y; };
+Point p;
+10 -> p.x;  20 -> p.y;
+[4]@!Point wpts;
+p -> wpts[0];
+42 -> wpts[0].x;
+printf("%ld %ld\n", p.x, p.y);

--- a/test/testdata/build-mgr/065_owned_struct_arr_mtrace.pa
+++ b/test/testdata/build-mgr/065_owned_struct_arr_mtrace.pa
@@ -1,0 +1,11 @@
+cinclude <stdio.h>;
+cinclude <mcheck.h>;
+type Point { int64 x; int64 y; };
+mtrace();
+{
+    [2]Point pts;
+    5 -> pts[0].x;
+    7 -> pts[1].x;
+    printf("%ld %ld\n", pts[0].x, pts[1].x);
+}
+muntrace();

--- a/test/testdata/build-mgr/066_embed_struct_arr_mtrace.pa
+++ b/test/testdata/build-mgr/066_embed_struct_arr_mtrace.pa
@@ -1,0 +1,10 @@
+cinclude <stdio.h>;
+cinclude <mcheck.h>;
+type Point { int64 x; int64 y; };
+mtrace();
+{
+    [3]$Point pts;
+    30 -> pts[1].x;
+    printf("%ld\n", pts[1].x);
+}
+muntrace();

--- a/test/testdata/build-mgr/067_at_struct_arr_mtrace.pa
+++ b/test/testdata/build-mgr/067_at_struct_arr_mtrace.pa
@@ -1,0 +1,12 @@
+cinclude <stdio.h>;
+cinclude <mcheck.h>;
+type Point { int64 x; int64 y; };
+Point p;
+99 -> p.x;
+mtrace();
+{
+    [4]@Point rpts;
+    p -> rpts[0];
+    printf("%ld\n", rpts[0].x);
+}
+muntrace();

--- a/test/testdata/build-mgr/068_at_bang_struct_arr_mtrace.pa
+++ b/test/testdata/build-mgr/068_at_bang_struct_arr_mtrace.pa
@@ -1,0 +1,13 @@
+cinclude <stdio.h>;
+cinclude <mcheck.h>;
+type Point { int64 x; int64 y; };
+Point p;
+10 -> p.x;
+mtrace();
+{
+    [4]@!Point wpts;
+    p -> wpts[0];
+    42 -> wpts[0].x;
+    printf("%ld\n", p.x);
+}
+muntrace();

--- a/test/testdata/gen-ast/028_arr_at_struct.pa
+++ b/test/testdata/gen-ast/028_arr_at_struct.pa
@@ -1,0 +1,2 @@
+type Point { int64 x; int64 y; };
+[4]@Point rpts;

--- a/test/testdata/gen-ast/029_arr_at_bang_struct.pa
+++ b/test/testdata/gen-ast/029_arr_at_bang_struct.pa
@@ -1,0 +1,2 @@
+type Point { int64 x; int64 y; };
+[4]@!Point wpts;

--- a/test/testdata/gen-ast/030_func_arr_at_struct_param.pa
+++ b/test/testdata/gen-ast/030_func_arr_at_struct_param.pa
@@ -1,0 +1,2 @@
+type Point { int64 x; int64 y; };
+func f([]@!Point pts, int64 n) { }

--- a/test/testdata/sa/098_embed_struct_arr.pa
+++ b/test/testdata/sa/098_embed_struct_arr.pa
@@ -2,6 +2,7 @@ cinclude <stdlib.h>;
 type Point { int64 x; int64 y; };
 func test() {
     [4]$Point pts;
+    pts[0];
     return;
 }
 test();

--- a/test/testdata/sa/098_embed_struct_arr.pa
+++ b/test/testdata/sa/098_embed_struct_arr.pa
@@ -1,0 +1,7 @@
+cinclude <stdlib.h>;
+type Point { int64 x; int64 y; };
+func test() {
+    [4]$Point pts;
+    return;
+}
+test();

--- a/test/testdata/sa/099_owned_struct_arr.pa
+++ b/test/testdata/sa/099_owned_struct_arr.pa
@@ -2,6 +2,7 @@ cinclude <stdlib.h>;
 type Point { int64 x; int64 y; };
 func test() {
     [2]Point pts;
+    pts[0];
     return;
 }
 test();

--- a/test/testdata/sa/099_owned_struct_arr.pa
+++ b/test/testdata/sa/099_owned_struct_arr.pa
@@ -1,0 +1,7 @@
+cinclude <stdlib.h>;
+type Point { int64 x; int64 y; };
+func test() {
+    [2]Point pts;
+    return;
+}
+test();

--- a/test/testdata/sa/100_at_struct_arr.pa
+++ b/test/testdata/sa/100_at_struct_arr.pa
@@ -1,0 +1,7 @@
+cinclude <stdlib.h>;
+type Point { int64 x; int64 y; };
+func test() {
+    [4]@Point rpts;
+    return;
+}
+test();

--- a/test/testdata/sa/100_at_struct_arr.pa
+++ b/test/testdata/sa/100_at_struct_arr.pa
@@ -2,6 +2,7 @@ cinclude <stdlib.h>;
 type Point { int64 x; int64 y; };
 func test() {
     [4]@Point rpts;
+    rpts[0];
     return;
 }
 test();

--- a/test/testdata/sa/102_at_bang_struct_arr.pa
+++ b/test/testdata/sa/102_at_bang_struct_arr.pa
@@ -1,0 +1,7 @@
+cinclude <stdlib.h>;
+type Point { int64 x; int64 y; };
+func test() {
+    [4]@!Point wpts;
+    return;
+}
+test();

--- a/test/testdata/sa/102_at_bang_struct_arr.pa
+++ b/test/testdata/sa/102_at_bang_struct_arr.pa
@@ -2,6 +2,7 @@ cinclude <stdlib.h>;
 type Point { int64 x; int64 y; };
 func test() {
     [4]@!Point wpts;
+    wpts[0];
     return;
 }
 test();

--- a/test/testdata/sa/103_embed_struct_arr_field.pa
+++ b/test/testdata/sa/103_embed_struct_arr_field.pa
@@ -1,0 +1,11 @@
+cinclude <stdlib.h>;
+cinclude <stdio.h>;
+type Point { int64 x; int64 y; };
+func test() {
+    [4]$Point pts;
+    10 -> pts[0].x;
+    20 -> pts[0].y;
+    printf("%ld %ld\n", pts[0].x, pts[0].y);
+    return;
+}
+test();

--- a/test/testdata/sa/104_owned_struct_arr_field.pa
+++ b/test/testdata/sa/104_owned_struct_arr_field.pa
@@ -1,0 +1,10 @@
+cinclude <stdlib.h>;
+cinclude <stdio.h>;
+type Point { int64 x; int64 y; };
+func test() {
+    [2]Point pts;
+    5 -> pts[0].x;
+    printf("%ld\n", pts[0].x);
+    return;
+}
+test();

--- a/test/testdata/sa/105_at_bang_struct_arr_field.pa
+++ b/test/testdata/sa/105_at_bang_struct_arr_field.pa
@@ -1,0 +1,12 @@
+cinclude <stdlib.h>;
+cinclude <stdio.h>;
+type Point { int64 x; int64 y; };
+func test() {
+    Point p;
+    [4]@!Point wpts;
+    p -> wpts[0];
+    42 -> wpts[0].x;
+    printf("%ld\n", p.x);
+    return;
+}
+test();

--- a/test/testdata/sa/106_at_struct_arr_field_read.pa
+++ b/test/testdata/sa/106_at_struct_arr_field_read.pa
@@ -1,0 +1,11 @@
+cinclude <stdlib.h>;
+cinclude <stdio.h>;
+type Point { int64 x; int64 y; };
+func test() {
+    Point p;
+    [4]@Point rpts;
+    p -> rpts[0];
+    printf("%ld\n", rpts[0].x);
+    return;
+}
+test();

--- a/test/testdata/sa/error_076_embed_arr_owned_struct.pa
+++ b/test/testdata/sa/error_076_embed_arr_owned_struct.pa
@@ -1,0 +1,4 @@
+cinclude <stdlib.h>;
+type Inner { int64 v; };
+type Outer { Inner child; };
+[4]$Outer arr;

--- a/test/testdata/sa/error_077_write_readonly_arr_elem.pa
+++ b/test/testdata/sa/error_077_write_readonly_arr_elem.pa
@@ -1,0 +1,8 @@
+cinclude <stdlib.h>;
+type Point { int64 x; int64 y; };
+func test() {
+    [4]@Point rpts;
+    42 -> rpts[0].x;
+    return;
+}
+test();

--- a/test/testdata/sa/error_078_field_access_on_arr_index_non_struct.pa
+++ b/test/testdata/sa/error_078_field_access_on_arr_index_non_struct.pa
@@ -1,0 +1,7 @@
+cinclude <stdio.h>;
+func test() {
+    [4]int64 arr;
+    printf("%ld\n", arr[0].x);
+    return;
+}
+test();

--- a/test/testdata/sa/error_079_field_assign_on_arr_index_non_struct.pa
+++ b/test/testdata/sa/error_079_field_assign_on_arr_index_non_struct.pa
@@ -1,0 +1,7 @@
+cinclude <stdlib.h>;
+func test() {
+    [4]int64 arr;
+    10 -> arr[0].x;
+    return;
+}
+test();


### PR DESCRIPTION
## Summary

- Add four forms of struct array variable declarations: `[n]$T` (contiguous inline), `[n]T` (owned pointer array), `[n]@T` (non-owning read-only), `[n]@!T` (non-owning mutable)
- Support `pts[i].field` access for all forms via `resolveObjectChain`
- Auto-generate `__pln_alloc_arr_T` / `__pln_free_arr_T` allocators in build-mgr from `arr-struct` alloc-shapes

## Tickets

| Ticket | Description |
|---|---|
| IT-2401 | gen-ast: `[n]@T` / `[n]@!T` variable declarations and `[]@!T` function signatures |
| IT-2402 | SA: `[n]$T` contiguous struct array (stride = T.totalSize) |
| IT-2403 | SA: `[n]T` owned pointer array + `arr_T` alloc-shapes registration |
| IT-2404 | SA: `[n]@T` / `[n]@!T` non-owning pointer arrays |
| IT-2405 | SA: `pts[i]` yields `pntr(struct(T))` for struct element types |
| IT-2406 | SA: `pts[i].field` access via `resolveObjectChain` base case |
| IT-2407 | build-mgr: generate `__pln_alloc_arr_T` / `__pln_free_arr_T` from `arr-struct` shapes |
| IT-2408 | Tests, docs (PalanReference, SASpec), and version bump to 0.1.24 |

## Test plan

- [ ] `make` passes all 77 tests (build-mgr-tester includes 3 new struct array tests: 062–064)
- [ ] `[n]$T` contiguous array: field read/write verified
- [ ] `[n]T` owned pointer array: element alloc/free via generated allocators verified
- [ ] `[n]@T` / `[n]@!T` non-owning arrays: pointer assignment and write-through verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)